### PR TITLE
CALCITE-1364 Docker images for an avatica server

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,46 @@
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+This module contains a number of Docker images to ease testing of
+Avatica clients against a known-server.
+
+## Docker
+
+`src/main/docker` contains a number of Docker images and Docker-compose
+configuration files to launch a standalone-Avatica server. Maven automation
+exists for the base Docker image "avatica-server" which can be invoked with
+the "-Pdocker" Maven profile.
+
+The other Docker images must be built by hand.
+
+### Provided Images
+
+A number of Docker images for different databases are provided. Presently, they include:
+
+* [HyperSQL](https://github.com/apache/calcite-avatica/tree/master/docker/src/main/docker/hypersql)
+* [MySQL](https://github.com/apache/calcite-avatica/tree/master/docker/src/main/docker/mysql)
+* [PostgreSQL(https://github.com/apache/calcite-avatica/tree/master/docker/src/main/docker/postgresql)
+
+## Dockerhub
+
+`src/main/dockerhub` contains a copy of the same `avatica-server` Dockerfile
+that is present in `src/main/docker` that is designed to be used with the
+automation around publishing Docker images to the Apache Dockerhub account.
+
+It is not expected that users would interact with this Dockerfile.

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,25 +17,25 @@ limitations under the License.
 {% endcomment %}
 -->
 
-This module contains a number of Docker images to ease testing of
+This module contains a number of Dockerfiles to ease testing of
 Avatica clients against a known-server.
 
 ## Docker
 
-`src/main/docker` contains a number of Docker images and Docker-compose
+`src/main/docker` contains a number of Dockerfiles and Docker-compose
 configuration files to launch a standalone-Avatica server. Maven automation
 exists for the base Docker image "avatica-server" which can be invoked with
 the "-Pdocker" Maven profile.
 
-The other Docker images must be built by hand.
+The other Dockerfiles must be built by hand.
 
 ### Provided Images
 
-A number of Docker images for different databases are provided. Presently, they include:
+A number of Dockerfiles for different databases are provided. Presently, they include:
 
 * [HyperSQL](https://github.com/apache/calcite-avatica/tree/master/docker/src/main/docker/hypersql)
 * [MySQL](https://github.com/apache/calcite-avatica/tree/master/docker/src/main/docker/mysql)
-* [PostgreSQL(https://github.com/apache/calcite-avatica/tree/master/docker/src/main/docker/postgresql)
+* [PostgreSQL](https://github.com/apache/calcite-avatica/tree/master/docker/src/main/docker/postgresql)
 
 ## Dockerhub
 

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.calcite.avatica</groupId>
+    <artifactId>avatica-parent</artifactId>
+    <version>1.10.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>avatica-docker</artifactId>
+  <packaging>pom</packaging>
+  <name>Apache Calcite Avatica Docker images</name>
+  <description>Docker images for the Avatica server</description>
+
+  <properties>
+    <top.dir>${project.basedir}/..</top.dir>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <!-- Use the execution instead of configuration to bind it to package -->
+        <executions>
+          <execution>
+            <id>binary-assembly</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <descriptors>
+                <descriptor>src/assembly/docker-files.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <!-- Profile for building official Docker images. Not bound to build phases since that would require anyone build to have the Docker engine installed on their machine -->
+    <profile>
+      <id>docker</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <imageName>avatica-server</imageName>
+              <dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
+              <imageTags>
+                <imageTag>${project.build.version}</imageTag>
+                <imageTag>latest</imageTag>
+              </imageTags>
+              <resources>
+                <resource>
+                  <targetPath>/</targetPath>
+                  <directory>${top.dir}/standalone-server/target</directory>
+                  <include>avatica-standalone-server-${project.build.version}-shaded.jar</include>
+                </resource>
+              </resources>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- Need to verify that the URL we're pulling from in the Dockerfile is correct for this release -->
+      <id>apache-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.gmaven</groupId>
+            <artifactId>groovy-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>check-dockerhub-dockerfile-version</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>execute</goal>
+                </goals>
+                <configuration>
+                  <source>${project.basedir}/src/test/scripts/verify-dockerhub-dockerfile-version.groovy</source>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -30,7 +30,6 @@ limitations under the License.
 
   <properties>
     <top.dir>${project.basedir}/..</top.dir>
-    <standalone.jar>avatica-standalone-server-${project.build.version}-shaded.jar</standalone.jar>
   </properties>
 
   <dependencies>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -30,8 +30,15 @@ limitations under the License.
 
   <properties>
     <top.dir>${project.basedir}/..</top.dir>
+    <standalone.jar>avatica-standalone-server-${project.build.version}-shaded.jar</standalone.jar>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.calcite.avatica</groupId>
+      <artifactId>avatica-standalone-server</artifactId>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>
@@ -75,14 +82,14 @@ limitations under the License.
               <imageName>avatica-server</imageName>
               <dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
               <imageTags>
-                <imageTag>${project.build.version}</imageTag>
+                <imageTag>${project.version}</imageTag>
                 <imageTag>latest</imageTag>
               </imageTags>
               <resources>
                 <resource>
                   <targetPath>/</targetPath>
                   <directory>${top.dir}/standalone-server/target</directory>
-                  <include>avatica-standalone-server-${project.build.version}-shaded.jar</include>
+                  <include>avatica-standalone-server-${project.version}-shaded.jar</include>
                 </resource>
               </resources>
             </configuration>

--- a/docker/src/assembly/docker-files.xml
+++ b/docker/src/assembly/docker-files.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+  <id>docker-files</id>
+  <formats>
+    <format>tar.gz</format>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>src/main/docker</directory>
+      <outputDirectory></outputDirectory>
+      <includes>
+        <include>**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/docker/src/main/docker/Dockerfile
+++ b/docker/src/main/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN addgroup -S avatica && adduser -S -G avatica avatica
 RUN mkdir -p /home/avatica/classpath
 
 # Dependencies
+# TODO would be nice to remove the hard-coded version
 ADD avatica-standalone-server-1.10.0-SNAPSHOT-shaded.jar /home/avatica/classpath
 
 # Make sure avatica owns its files
@@ -28,6 +29,9 @@ RUN chown -R avatica: /home/avatica
 
 # Expose the default port as a convenience
 EXPOSE 8765
+
 # Switch off of the root user
 # TODO Would like to do this, but screws up downstream due to https://github.com/docker/docker/issues/6119
 # USER avatica
+
+ENTRYPOINT ["/usr/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer", "-p", "8765"]

--- a/docker/src/main/docker/Dockerfile
+++ b/docker/src/main/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p /home/avatica/classpath
 
 # Dependencies
 # TODO would be nice to remove the hard-coded version
-ADD avatica-standalone-server-1.10.0-SNAPSHOT-shaded.jar /home/avatica/classpath
+ADD avatica-standalone-server-*-shaded.jar /home/avatica/classpath
 
 # Make sure avatica owns its files
 RUN chown -R avatica: /home/avatica

--- a/docker/src/main/docker/Dockerfile
+++ b/docker/src/main/docker/Dockerfile
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 MAINTAINER Apache Avatica <dev@calcite.apache.org>
 
 # Create an avatica user
-RUN useradd -m avatica
+RUN addgroup -S avatica && adduser -S -G avatica avatica
 RUN mkdir -p /home/avatica/classpath
 
 # Dependencies

--- a/docker/src/main/docker/Dockerfile
+++ b/docker/src/main/docker/Dockerfile
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM openjdk:8-jre
+MAINTAINER Apache Avatica <dev@calcite.apache.org>
+
+# Create an avatica user
+RUN useradd -m avatica
+RUN mkdir -p /home/avatica/classpath
+
+# Dependencies
+ADD avatica-standalone-server-1.10.0-SNAPSHOT-shaded.jar /home/avatica/classpath
+
+# Make sure avatica owns its files
+RUN chown -R avatica: /home/avatica
+
+# Expose the default port as a convenience
+EXPOSE 8765
+# Switch off of the root user
+# TODO Would like to do this, but screws up downstream due to https://github.com/docker/docker/issues/6119
+# USER avatica

--- a/docker/src/main/docker/Dockerfile
+++ b/docker/src/main/docker/Dockerfile
@@ -21,7 +21,6 @@ RUN addgroup -S avatica && adduser -S -G avatica avatica
 RUN mkdir -p /home/avatica/classpath
 
 # Dependencies
-# TODO would be nice to remove the hard-coded version
 ADD avatica-standalone-server-*-shaded.jar /home/avatica/classpath
 
 # Make sure avatica owns its files

--- a/docker/src/main/docker/hypersql/Dockerfile
+++ b/docker/src/main/docker/hypersql/Dockerfile
@@ -16,8 +16,11 @@
 FROM avatica-server:latest
 MAINTAINER Apache Avatica <dev@calcite.apache.org>
 
+ARG HSQLDB_VERSION="2.3.1"
+
 # Dependencies
 ADD https://repo1.maven.org/maven2/net/hydromatic/scott-data-hsqldb/0.1/scott-data-hsqldb-0.1.jar /home/avatica/classpath/
-ADD https://repo1.maven.org/maven2/org/hsqldb/hsqldb/2.3.1/hsqldb-2.3.1.jar /home/avatica/classpath/
+ADD https://repo1.maven.org/maven2/org/hsqldb/hsqldb/${HSQLDB_VERSION}/hsqldb-${HSQLDB_VERSION}.jar /home/avatica/classpath/
 
-ENTRYPOINT ["/usr/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer", "-u", "jdbc:hsqldb:res:scott"]
+# Add on to avatica-server's entrypoint
+CMD ["-u", "jdbc:hsqldb:res:scott"]

--- a/docker/src/main/docker/hypersql/Dockerfile
+++ b/docker/src/main/docker/hypersql/Dockerfile
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM avatica-server:latest
+MAINTAINER Apache Avatica <dev@calcite.apache.org>
+
+# Dependencies
+ADD https://repo1.maven.org/maven2/net/hydromatic/scott-data-hsqldb/0.1/scott-data-hsqldb-0.1.jar /home/avatica/classpath/
+ADD https://repo1.maven.org/maven2/org/hsqldb/hsqldb/2.3.1/hsqldb-2.3.1.jar /home/avatica/classpath/
+
+ENTRYPOINT ["/usr/lib/jvm/java-8-openjdk-amd64/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer", "-u", "jdbc:hsqldb:res:scott"]

--- a/docker/src/main/docker/hypersql/Dockerfile
+++ b/docker/src/main/docker/hypersql/Dockerfile
@@ -20,4 +20,4 @@ MAINTAINER Apache Avatica <dev@calcite.apache.org>
 ADD https://repo1.maven.org/maven2/net/hydromatic/scott-data-hsqldb/0.1/scott-data-hsqldb-0.1.jar /home/avatica/classpath/
 ADD https://repo1.maven.org/maven2/org/hsqldb/hsqldb/2.3.1/hsqldb-2.3.1.jar /home/avatica/classpath/
 
-ENTRYPOINT ["/usr/lib/jvm/java-8-openjdk-amd64/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer", "-u", "jdbc:hsqldb:res:scott"]
+ENTRYPOINT ["/usr/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer", "-u", "jdbc:hsqldb:res:scott"]

--- a/docker/src/main/docker/hypersql/build.sh
+++ b/docker/src/main/docker/hypersql/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd "$(dirname "$0")"
+
+docker build . -t avatica-hsqldb-server

--- a/docker/src/main/docker/mysql/Dockerfile
+++ b/docker/src/main/docker/mysql/Dockerfile
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM avatica-server:latest
+MAINTAINER Apache Avatica <dev@calcite.apache.org>
+
+# Dependencies
+ADD https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar /home/avatica/classpath/
+RUN chown -R avatica: /home/avatica
+
+USER avatica
+ENTRYPOINT ["/usr/lib/jvm/java-8-openjdk-amd64/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer"]

--- a/docker/src/main/docker/mysql/Dockerfile
+++ b/docker/src/main/docker/mysql/Dockerfile
@@ -21,4 +21,4 @@ ADD https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.41/mysql-conne
 RUN chown -R avatica: /home/avatica
 
 USER avatica
-ENTRYPOINT ["/usr/lib/jvm/java-8-openjdk-amd64/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer"]
+ENTRYPOINT ["/usr/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer"]

--- a/docker/src/main/docker/mysql/Dockerfile
+++ b/docker/src/main/docker/mysql/Dockerfile
@@ -16,9 +16,10 @@
 FROM avatica-server:latest
 MAINTAINER Apache Avatica <dev@calcite.apache.org>
 
+ARG MYSQL_VERSION="5.1.41"
+
 # Dependencies
-ADD https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar /home/avatica/classpath/
+ADD https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_VERSION}/mysql-connector-java-${MYSQL_VERSION}.jar /home/avatica/classpath/
 RUN chown -R avatica: /home/avatica
 
 USER avatica
-ENTRYPOINT ["/usr/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer"]

--- a/docker/src/main/docker/mysql/build.sh
+++ b/docker/src/main/docker/mysql/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd "$(dirname "$0")"
+
+docker build . -t avatica-mysql-server

--- a/docker/src/main/docker/mysql/docker-compose.yml
+++ b/docker/src/main/docker/mysql/docker-compose.yml
@@ -20,14 +20,13 @@ services:
       - "8765:8765"
     links:
       - mysql
+    build: ./
     image: avatica-mysql-server
     command: "-u 'jdbc:mysql://mysql:3306/avatica' -p 8765"
     depends_on:
       - mysql
   mysql:
     image: mysql:5.7
-    ports:
-      - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: avatica
       MYSQL_DATABASE: avatica

--- a/docker/src/main/docker/mysql/docker-compose.yml
+++ b/docker/src/main/docker/mysql/docker-compose.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '2'
+services:
+  avatica:
+    ports:
+      - "8765:8765"
+    links:
+      - mysql
+    image: avatica-mysql-server
+    command: "-u 'jdbc:mysql://mysql:3306/avatica' -p 8765"
+    depends_on:
+      - mysql
+  mysql:
+    image: mysql:5.7
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: avatica
+      MYSQL_DATABASE: avatica
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password

--- a/docker/src/main/docker/mysql/docker-compose.yml
+++ b/docker/src/main/docker/mysql/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - mysql
     build: ./
     image: avatica-mysql-server
-    command: "-u 'jdbc:mysql://mysql:3306/avatica' -p 8765"
+    command: "-u 'jdbc:mysql://mysql:3306/avatica'"
     depends_on:
       - mysql
   mysql:

--- a/docker/src/main/docker/postgresql/Dockerfile
+++ b/docker/src/main/docker/postgresql/Dockerfile
@@ -16,9 +16,10 @@
 FROM avatica-server:latest
 MAINTAINER Apache Avatica <dev@calcite.apache.org>
 
+ARG POSTGRESQL_VERSION="42.0.0.jre7"
+
 # Dependencies
-ADD https://repo1.maven.org/maven2/org/postgresql/postgresql/42.0.0.jre7/postgresql-42.0.0.jre7.jar /home/avatica/classpath/
+ADD https://repo1.maven.org/maven2/org/postgresql/postgresql/${POSTGRESQL_VERSION}/postgresql-${POSTGRESQL_VERSION}.jar /home/avatica/classpath/
 RUN chown -R avatica: /home/avatica
 
 USER avatica
-ENTRYPOINT ["/usr/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer"]

--- a/docker/src/main/docker/postgresql/Dockerfile
+++ b/docker/src/main/docker/postgresql/Dockerfile
@@ -16,7 +16,7 @@
 FROM avatica-server:latest
 MAINTAINER Apache Avatica <dev@calcite.apache.org>
 
-ARG POSTGRESQL_VERSION="42.0.0.jre7"
+ARG POSTGRESQL_VERSION="42.0.0"
 
 # Dependencies
 ADD https://repo1.maven.org/maven2/org/postgresql/postgresql/${POSTGRESQL_VERSION}/postgresql-${POSTGRESQL_VERSION}.jar /home/avatica/classpath/

--- a/docker/src/main/docker/postgresql/Dockerfile
+++ b/docker/src/main/docker/postgresql/Dockerfile
@@ -21,4 +21,4 @@ ADD https://repo1.maven.org/maven2/org/postgresql/postgresql/42.0.0.jre7/postgre
 RUN chown -R avatica: /home/avatica
 
 USER avatica
-ENTRYPOINT ["/usr/lib/jvm/java-8-openjdk-amd64/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer"]
+ENTRYPOINT ["/usr/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer"]

--- a/docker/src/main/docker/postgresql/Dockerfile
+++ b/docker/src/main/docker/postgresql/Dockerfile
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM avatica-server:latest
+MAINTAINER Apache Avatica <dev@calcite.apache.org>
+
+# Dependencies
+ADD https://repo1.maven.org/maven2/org/postgresql/postgresql/42.0.0.jre7/postgresql-42.0.0.jre7.jar /home/avatica/classpath/
+RUN chown -R avatica: /home/avatica
+
+USER avatica
+ENTRYPOINT ["/usr/lib/jvm/java-8-openjdk-amd64/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer"]

--- a/docker/src/main/docker/postgresql/build.sh
+++ b/docker/src/main/docker/postgresql/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd "$(dirname "$0")"
+
+docker build . -t avatica-postgresql-server

--- a/docker/src/main/docker/postgresql/docker-compose.yml
+++ b/docker/src/main/docker/postgresql/docker-compose.yml
@@ -20,15 +20,14 @@ services:
       - "8765:8765"
     links:
       - postgresql
+    build: ./
     image: avatica-postgresql-server
+    # Default port for the docker image
     command: "-u 'jdbc:postgresql://postgresql:5432/avatica' -p 8765"
     depends_on:
       - postgresql
   postgresql:
     image: postgres:9.6
-    ports:
-      # Default port for the docker image
-      - "5432:5432"
     environment:
       POSTGRES_DB: avatica
       POSTGRES_USER: user

--- a/docker/src/main/docker/postgresql/docker-compose.yml
+++ b/docker/src/main/docker/postgresql/docker-compose.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '2'
+services:
+  avatica:
+    ports:
+      - "8765:8765"
+    links:
+      - postgresql
+    image: avatica-postgresql-server
+    command: "-u 'jdbc:postgresql://postgresql:5432/avatica' -p 8765"
+    depends_on:
+      - postgresql
+  postgresql:
+    image: postgres:9.6
+    ports:
+      # Default port for the docker image
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: avatica
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password

--- a/docker/src/main/docker/postgresql/docker-compose.yml
+++ b/docker/src/main/docker/postgresql/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     build: ./
     image: avatica-postgresql-server
     # Default port for the docker image
-    command: "-u 'jdbc:postgresql://postgresql:5432/avatica' -p 8765"
+    command: "-u 'jdbc:postgresql://postgresql:5432/avatica'"
     depends_on:
       - postgresql
   postgresql:

--- a/docker/src/main/dockerhub/Dockerfile
+++ b/docker/src/main/dockerhub/Dockerfile
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 MAINTAINER Apache Avatica <dev@calcite.apache.org>
 
 # Create an avatica user
-RUN useradd -m avatica
+RUN addgroup -S avatica && adduser -S -G avatica avatica
 RUN mkdir -p /home/avatica/classpath
 
 # This line must be preserved. The Maven build will verify this version matches its version

--- a/docker/src/main/dockerhub/Dockerfile
+++ b/docker/src/main/dockerhub/Dockerfile
@@ -34,3 +34,5 @@ EXPOSE 8765
 
 # TODO Would like to do this, but screws up downstream due to https://github.com/docker/docker/issues/6119
 # USER avatica
+
+ENTRYPOINT ["/usr/bin/java", "-cp", "/home/avatica/classpath/*", "org.apache.calcite.avatica.standalone.StandaloneServer", "-p", "8765"]

--- a/docker/src/main/dockerhub/Dockerfile
+++ b/docker/src/main/dockerhub/Dockerfile
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM openjdk:8-jre
+MAINTAINER Apache Avatica <dev@calcite.apache.org>
+
+# Create an avatica user
+RUN useradd -m avatica
+RUN mkdir -p /home/avatica/classpath
+
+# This line must be preserved. The Maven build will verify this version matches its version
+ARG AVATICA_VERSION="1.10.0"
+
+# Dependencies
+ADD https://repository.apache.org/content/groups/public/org/apache/calcite/avatica/avatica-standalone-server/${AVATICA_VERSION}/avatica-standalone-server-${AVATICA_VERSION}-shaded.jar /home/avatica/classpath
+
+# Make sure avatica owns its files
+RUN chown -R avatica: /home/avatica
+
+# Expose the default port as a convenience
+EXPOSE 8765
+
+# TODO Would like to do this, but screws up downstream due to https://github.com/docker/docker/issues/6119
+# USER avatica

--- a/docker/src/test/scripts/verify-dockerhub-dockerfile-version.groovy
+++ b/docker/src/test/scripts/verify-dockerhub-dockerfile-version.groovy
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+import java.nio.file.Files;
+
+System.out.println("Verifying the included version in the Dockerhub Dockerfile");
+
+String expectedPrefix = "ARG AVATICA_VERSION=";
+String expectedVersion = project.getVersion();
+
+if (null == expectedVersion) {
+  throw new IllegalArgumentException("Did not find Maven project version");
+}
+
+String dockerfilePath = "src/main/dockerhub/Dockerfile";
+File dockerfile = new File(basedir, dockerfilePath);
+if (!dockerfile.isFile()) {
+  throw new FileNotFoundException("Could not file dockerhub Dockerfile at " + dockerfilePath);
+}
+
+List<String> lines = Files.readAllLines(dockerfile.toPath());
+for (String line : lines) {
+  line = line.trim();
+  if (line.startsWith(expectedPrefix)) {
+    String value = line.substring(expectedPrefix.length());
+    // Trim leading and trailing quotation marks
+    value = value.substring(1, value.length() - 1);
+    if (expectedVersion.equals(value)) {
+      System.out.println("Found expected version in DockerHub dockerfile of " + value);
+      return true;
+    } else {
+      throw new IllegalArgumentException("Expected Avatica version of " + expectedVersion + " but got " + value);
+    }
+  }
+}
+
+throw new IllegalArgumentException("Could not extract Avatica version from " + dockerfile);

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,11 @@ limitations under the License.
       </dependency>
       <dependency>
         <groupId>org.apache.calcite.avatica</groupId>
+        <artifactId>avatica-standalone-server</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.calcite.avatica</groupId>
         <artifactId>avatica-core</artifactId>
         <version>${project.version}</version>
         <type>test-jar</type>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@ limitations under the License.
 
   <modules>
     <module>core</module>
+    <module>docker</module>
     <module>metrics</module>
     <module>metrics-dropwizardmetrics3</module>
     <module>noop-driver</module>
@@ -520,6 +521,11 @@ limitations under the License.
           </dependencies>
         </plugin>
         <plugin>
+          <groupId>com.spotify</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>0.4.13</version>
+        </plugin>
+        <plugin>
           <groupId>de.thetaphi</groupId>
           <artifactId>forbiddenapis</artifactId>
           <version>${forbiddenapis.version}</version>
@@ -589,6 +595,11 @@ limitations under the License.
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>${build-helper-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.gmaven</groupId>
+          <artifactId>groovy-maven-plugin</artifactId>
+          <version>2.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/site/_data/docs.yml
+++ b/site/_data/docs.yml
@@ -29,6 +29,7 @@
   - security
   - compatibility
   - custom_client_artifacts
+  - docker
 
 - title: Meta
   docs:

--- a/site/_docs/docker_images.md
+++ b/site/_docs/docker_images.md
@@ -52,8 +52,8 @@ To make the lives of end-users who want to use a specific database easier, some 
 images are provided for some common databases. The current databases include:
 
 * [HyperSQL](http://hsqldb.org) (2.3.1)
-* [MySQL](https://www.mysql.com/) (5.1.41)
-* [PostgreSQL](https://www.postgresql.org/) (42.0)
+* [MySQL](https://www.mysql.com/) (Client 5.1.41, supports MySQL server 4.1, 5.0, 5.1, 5.5, 5.6, 5.7)
+* [PostgreSQL](https://www.postgresql.org/) (Client 42.0.0, supports PostgreSQL servers >=8.3)
 
 These images are not deployed as the licensing on each database driver is varied. Please
 understand and accept the license of each before using in any software project.
@@ -123,3 +123,29 @@ To debug these docker images, the `ENTRYPOINT` can be overriden to launch a shel
 ```
 $ docker run --rm --entrypoint='' -it avatica-mysql-server /bin/sh
 ```
+
+### Running Docker containers for custom databases
+
+The provided `avatica-server` Docker image is designed to be generally reusable
+for developers that want to expose a database of their choosing. A custom Dockerfile
+can be created by copying what the `avatica-mysql-server` or `avatica-postgresql-server`
+do, but this is also achievable via the Docker volumes.
+
+For example, consider we have a JAR with a JDBC driver for our database on our local
+machine `/home/user/my-database-jars/my-database-jdbc-1.0.jar`. We can run the following command to
+launch a custom Avatica server against our database with this JDBC driver.
+
+```
+$ docker run --rm -p 8765:8765 \
+    -v /home/user/my-database-jars/:/my-database-jars --entrypoint="" -it avatica-server \
+    /usr/bin/java -cp "/home/avatica/classpath/*:/my-database-jars/*" \
+    org.apache.calcite.avatica.standalone.StandaloneServer -p 8765 \
+    -u "jdbc:my_jdbc_url"
+```
+
+This command does the following:
+
+* Exposes the internal port 8765 on the local machine as 8765
+* Maps the local directory "home/user/my-database-jars" to the Docker container at "/my-database-jars" using the Docker volumes feature
+* Adds that mapped directory to the Java classpath
+* Sets the correct JDBC URL for the database

--- a/site/_docs/docker_images.md
+++ b/site/_docs/docker_images.md
@@ -1,0 +1,125 @@
+---
+layout: docs
+title: Docker Images
+sidebar_title: Docker Images
+permalink: /docs/docker.html
+---
+
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+## Docker Images for Avatica
+
+[Docker](https://en.wikipedia.org/wiki/Docker_(software)) is a popular piece of
+software that enables other software to run "anywhere". In the context of Avatica,
+we can use Docker to enable a run-anywhere Avatica server. These Docker containers
+can be used to easily create a server for the development of custom Avatica clients
+or encapsulating database access for testing software that uses Avatica.
+
+### Base "avatica-server" Docker Image
+
+Starting with the Avatica 1.10.0 release, Avatica is providing a number of Docker
+containers. Each of these images is based on a "parent" "avatica-server" Docker image.
+
+This Docker image has no bindings to a specific database (it has not database-specific
+JDBC driver included). It only contains a Java runtime and the Avatica Standalone Server
+jar (which contains all the necessary dependencies of the Avatica server). This docker
+image is not directly useful for end users; it is useful for those who want to use Avatica
+with a database of their choosing.
+
+This Docker image will be deployed to the [Apache Dockerhub account](https://hub.docker.com/r/apache/) after the release
+of 1.10.0 and will be updated for future releases of Avatica.
+
+### Database-specific Docker Images
+
+To make the lives of end-users who want to use a specific database easier, some Docker
+images are provided for some common databases. The current databases include:
+
+* [HyperSQL](http://hsqldb.org) (2.3.1)
+* [MySQL](https://www.mysql.com/) (5.1.41)
+* [PostgreSQL](https://www.postgresql.org/) (42.0)
+
+These images are not deployed as the licensing on each database driver is varied. Please
+understand and accept the license of each before using in any software project.
+
+Each of these images include a `build.sh` script which will build the docker image using
+the latest `avatica-server` Docker image. The resulting Docker image will be named according
+to the following format: `avatica-<database>-server`. For example, `avatica-hsqldb-server`,
+`avatica-mysql-server`, and `avatica-postgresql-server`.
+
+Additionally, [Docker Compose](https://github.com/docker/compose) configuration files for the above
+databases (sans HyperSQL) are provided which configure the database's standard Docker image
+and then connect Avatica to that Docker container. For example, the PostgreSQL docker-compose configuration
+file will start an instance of PostgreSQL and an instance of the Avatica server, each in their own container,
+exposing an Avatica server configured against a "real" PostgreSQL database.
+
+All of the `Dockerfile` and `docker-compose.yml` files are conveniently provided in an archive for
+each release, starting with 1.10.0.
+
+```
+avatica-docker-1.10.0-SNAPSHOT/
+avatica-docker-1.10.0-SNAPSHOT/hypersql/
+avatica-docker-1.10.0-SNAPSHOT/mysql/
+avatica-docker-1.10.0-SNAPSHOT/postgresql/
+avatica-docker-1.10.0-SNAPSHOT/Dockerfile
+avatica-docker-1.10.0-SNAPSHOT/hypersql/build.sh
+avatica-docker-1.10.0-SNAPSHOT/hypersql/Dockerfile
+avatica-docker-1.10.0-SNAPSHOT/mysql/build.sh
+avatica-docker-1.10.0-SNAPSHOT/mysql/docker-compose.yml
+avatica-docker-1.10.0-SNAPSHOT/mysql/Dockerfile
+avatica-docker-1.10.0-SNAPSHOT/postgresql/build.sh
+avatica-docker-1.10.0-SNAPSHOT/postgresql/docker-compose.yml
+avatica-docker-1.10.0-SNAPSHOT/postgresql/Dockerfile
+```
+
+#### Running
+
+Each of the provided database-specific Docker images set an `ENTRYPOINT` which
+encapsulate most of the Java command. The following options are available to specify:
+
+```
+Usage: <main class> [options]
+  Options:
+    -h, -help, --help
+       Print the help message
+       Default: false
+    -p, --port
+       Port the server should bind
+       Default: 0
+    -s, --serialization
+       Serialization method to use
+       Default: PROTOBUF
+       Possible Values: [JSON, PROTOBUF]
+  * -u, --url
+       JDBC driver url for the server
+```
+
+For example, to connect to a MySQL server, the following could be used:
+
+```
+$ ./avatica-docker-*/mysql/build.sh
+$ docker run --rm -it avatica-mysql-server \
+    -u jdbc:mysql://<fqdn>:3306/my_database -p 8765
+```
+
+To debug these docker images, the `ENTRYPOINT` can be overriden to launch a shell
+
+```
+$ docker run --rm --entrypoint='' -it avatica-mysql-server /bin/sh
+```

--- a/site/_docs/docker_images.md
+++ b/site/_docs/docker_images.md
@@ -115,7 +115,7 @@ For example, to connect to a MySQL server, the following could be used:
 ```
 $ ./avatica-docker-*/mysql/build.sh
 $ docker run --rm -it avatica-mysql-server \
-    -u jdbc:mysql://<fqdn>:3306/my_database -p 8765
+    -u jdbc:mysql://<fqdn>:3306/my_database
 ```
 
 To debug these docker images, the `ENTRYPOINT` can be overriden to launch a shell

--- a/standalone-server/pom.xml
+++ b/standalone-server/pom.xml
@@ -23,8 +23,8 @@ limitations under the License.
     <version>1.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>avatica-standalone-server</artifactId>
-  <name>Avatica Standalone Server</name>
-  <description>A Stadnalone Avatica Server Implementation</description>
+  <name>Apache Calcite Avatica Standalone Server</name>
+  <description>A Standalone Avatica Server Implementation</description>
 
   <properties>
     <top.dir>${project.basedir}/..</top.dir>

--- a/standalone-server/src/main/java/org/apache/calcite/avatica/standalone/StandaloneServer.java
+++ b/standalone-server/src/main/java/org/apache/calcite/avatica/standalone/StandaloneServer.java
@@ -99,7 +99,7 @@ public class StandaloneServer {
     JCommander jc = new JCommander(server, args);
     if (server.help) {
       jc.usage();
-      System.exit(1);
+      Unsafe.systemExit(ExitCodes.USAGE.ordinal());
       return;
     }
 
@@ -140,7 +140,8 @@ public class StandaloneServer {
   private enum ExitCodes {
     NORMAL,
     ALREADY_STARTED, // 1
-    START_FAILED;    // 2
+    START_FAILED,    // 2
+    USAGE;           // 3
   }
 }
 

--- a/standalone-server/src/main/java/org/apache/calcite/avatica/standalone/StandaloneServer.java
+++ b/standalone-server/src/main/java/org/apache/calcite/avatica/standalone/StandaloneServer.java
@@ -49,6 +49,10 @@ public class StandaloneServer {
       description = "Serialization method to use", converter = SerializationConverter.class)
   private Serialization serialization = Serialization.PROTOBUF;
 
+  @Parameter(names = { "-h", "-help", "--help" }, required = false, help = true,
+      description = "Print the help message")
+  private boolean help = false;
+
   private HttpServer server;
 
   public void start() {
@@ -92,7 +96,12 @@ public class StandaloneServer {
 
   public static void main(String[] args) {
     final StandaloneServer server = new StandaloneServer();
-    new JCommander(server, args);
+    JCommander jc = new JCommander(server, args);
+    if (server.help) {
+      jc.usage();
+      System.exit(1);
+      return;
+    }
 
     server.start();
 


### PR DESCRIPTION
* Includes a base Docker image for an Avatica server
* Includes "implementations" for hsqldb, postgresql, mysql
* Includes docker-compose files for postgresl/mysql + avatica
* Includes a base Docker image suitable for auto-promotion to Dockerhub
* Includes verification of versions in the Dockerhub Dockerfile
* An assembly built containing all docker files