### PR TITLE
[CALCITE-1884] DateTimeUtils produces incorrect results for days before the Gregorian cutovers

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/util/DateTimeUtils.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/DateTimeUtils.java
@@ -358,28 +358,24 @@ public class DateTimeUtils {
   }
 
   private static void julianToString(StringBuilder buf, int julian) {
-    // this shifts the epoch back to astronomical year -4800 instead of the
-    // start of the Christian era in year AD 1 of the proleptic Gregorian
-    // calendar.
-    int j = julian + 32044;
-    int g = j / 146097;
-    int dg = j % 146097;
-    int c = (dg / 36524 + 1) * 3 / 4;
-    int dc = dg - c * 36524;
-    int b = dc / 1461;
-    int db = dc % 1461;
-    int a = (db / 365 + 1) * 3 / 4;
-    int da = db - a * 365;
+    // Algorithm from the book "Astronomical Algorithms" by Jean Meeus, 1998
+    int b;
+    int c;
+    if (julian > 2299160) {
+      int a = julian + 32044;
+      b = (4 * a + 3) / 146097;
+      c = a - b * 146097 / 4;
+    } else {
+      b = 0;
+      c = julian + 32082;
+    }
+    int d = (4 * c + 3) / 1461;
+    int e = c - (1461 * d) / 4;
+    int m = (5 * e + 2) / 153;
+    int day = e - (153 * m + 2) / 5 + 1;
+    int month = m + 3 - 12 * (m / 10);
+    int year = b * 100 + d - 4800 + (m / 10);
 
-    // integer number of full years elapsed since March 1, 4801 BC
-    int y = g * 400 + c * 100 + b * 4 + a;
-    // integer number of full months elapsed since the last March 1
-    int m = (da * 5 + 308) / 153 - 2;
-    // number of days elapsed since day 1 of the month
-    int d = da - (m + 4) * 153 / 5 + 122;
-    int year = y - 4800 + (m + 2) / 12;
-    int month = (m + 2) % 12 + 1;
-    int day = d + 1;
     int4(buf, year);
     buf.append('-');
     int2(buf, month);
@@ -724,28 +720,24 @@ public class DateTimeUtils {
   }
 
   private static int julianExtract(TimeUnitRange range, int julian) {
-    // this shifts the epoch back to astronomical year -4800 instead of the
-    // start of the Christian era in year AD 1 of the proleptic Gregorian
-    // calendar.
-    int j = julian + 32044;
-    int g = j / 146097;
-    int dg = j % 146097;
-    int c = (dg / 36524 + 1) * 3 / 4;
-    int dc = dg - c * 36524;
-    int b = dc / 1461;
-    int db = dc % 1461;
-    int a = (db / 365 + 1) * 3 / 4;
-    int da = db - a * 365;
+    // Algorithm from the book "Astronomical Algorithms" by Jean Meeus, 1998
+    int b;
+    int c;
+    if (julian > 2299160) {
+      int a = julian + 32044;
+      b = (4 * a + 3) / 146097;
+      c = a - b * 146097 / 4;
+    } else {
+      b = 0;
+      c = julian + 32082;
+    }
+    int d = (4 * c + 3) / 1461;
+    int e = c - (1461 * d) / 4;
+    int m = (5 * e + 2) / 153;
+    int day = e - (153 * m + 2) / 5 + 1;
+    int month = m + 3 - 12 * (m / 10);
+    int year = b * 100 + d - 4800 + (m / 10);
 
-    // integer number of full years elapsed since March 1, 4801 BC
-    int y = g * 400 + c * 100 + b * 4 + a;
-    // integer number of full months elapsed since the last March 1
-    int m = (da * 5 + 308) / 153 - 2;
-    // number of days elapsed since day 1 of the month
-    int d = da - (m + 4) * 153 / 5 + 122;
-    int year = y - 4800 + (m + 2) / 12;
-    int month = (m + 2) % 12 + 1;
-    int day = d + 1;
     switch (range) {
     case YEAR:
       return year;
@@ -846,28 +838,24 @@ public class DateTimeUtils {
 
   private static int julianDateFloor(TimeUnitRange range, int julian,
       boolean floor) {
-    // this shifts the epoch back to astronomical year -4800 instead of the
-    // start of the Christian era in year AD 1 of the proleptic Gregorian
-    // calendar.
-    int j = julian + 32044;
-    int g = j / 146097;
-    int dg = j % 146097;
-    int c = (dg / 36524 + 1) * 3 / 4;
-    int dc = dg - c * 36524;
-    int b = dc / 1461;
-    int db = dc % 1461;
-    int a = (db / 365 + 1) * 3 / 4;
-    int da = db - a * 365;
+    // Algorithm from the book "Astronomical Algorithms" by Jean Meeus, 1998
+    int b;
+    int c;
+    if (julian > 2299160) {
+      int a = julian + 32044;
+      b = (4 * a + 3) / 146097;
+      c = a - b * 146097 / 4;
+    } else {
+      b = 0;
+      c = julian + 32082;
+    }
+    int d = (4 * c + 3) / 1461;
+    int e = c - (1461 * d) / 4;
+    int m = (5 * e + 2) / 153;
+    int day = e - (153 * m + 2) / 5 + 1;
+    int month = m + 3 - 12 * (m / 10);
+    int year = b * 100 + d - 4800 + (m / 10);
 
-    // integer number of full years elapsed since March 1, 4801 BC
-    int y = g * 400 + c * 100 + b * 4 + a;
-    // integer number of full months elapsed since the last March 1
-    int m = (da * 5 + 308) / 153 - 2;
-    // number of days elapsed since day 1 of the month
-    int d = da - (m + 4) * 153 / 5 + 122;
-    int year = y - 4800 + (m + 2) / 12;
-    int month = (m + 2) % 12 + 1;
-    int day = d + 1;
     switch (range) {
     case YEAR:
       if (!floor && (month > 1 || day > 1)) {

--- a/core/src/test/java/org/apache/calcite/avatica/util/DateTimeUtilsTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/DateTimeUtilsTest.java
@@ -128,6 +128,15 @@ public class DateTimeUtilsTest {
     assertEquals(-25508, ymdToUnixDate(1900, 3, 1));
   }
 
+  @Test public void testDateConversion() {
+    for (int i = 0; i < 4000; ++i) {
+      for (int j = 1; j <= 12; ++j) {
+        String date = String.format(Locale.ENGLISH, "%04d-%02d-28", i, j);
+        assertEquals(date, unixDateToString(ymdToUnixDate(i, j, 28)));
+      }
+    }
+  }
+
   @Test public void testDateToString() {
     checkDateString("1970-01-01", 0);
     //noinspection PointlessArithmeticExpression

--- a/core/src/test/java/org/apache/calcite/avatica/util/DateTimeUtilsTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/DateTimeUtilsTest.java
@@ -410,11 +410,9 @@ public class DateTimeUtilsTest {
     assertThat(
         unixDateExtract(TimeUnitRange.CENTURY, ymdToUnixDate(1, 2, 1)),
         is(1L));
-    // TODO: For a small time range around year 1, due to the Gregorian shift,
-    // we end up in the wrong century. Should be 1.
     assertThat(
         unixDateExtract(TimeUnitRange.CENTURY, ymdToUnixDate(1, 1, 1)),
-        is(0L));
+        is(1L));
     assertThat(
         unixDateExtract(TimeUnitRange.CENTURY, ymdToUnixDate(-2, 1, 1)),
         is(-1L));
@@ -429,11 +427,9 @@ public class DateTimeUtilsTest {
     assertThat(
         unixDateExtract(TimeUnitRange.MILLENNIUM, ymdToUnixDate(1852, 6, 7)),
         is(2L));
-    // TODO: For a small time range around year 1, due to the Gregorian shift,
-    // we end up in the wrong millennium. Should be 1.
     assertThat(
         unixDateExtract(TimeUnitRange.MILLENNIUM, ymdToUnixDate(1, 1, 1)),
-        is(0L));
+        is(1L));
     assertThat(
         unixDateExtract(TimeUnitRange.MILLENNIUM, ymdToUnixDate(1, 2, 1)),
         is(1L));


### PR DESCRIPTION
This PR augments the supports of Julian days that are before the Gregorian cutovers in DateTimeUtils.

It implements the algorithm from the book "Astronomical Algorithms" by Jean Meeus, 1998.