### PR TITLE
CALCITE-2073 Allow disabling of the maven-protobuf-plugin

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -179,19 +179,6 @@ limitations under the License.
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
-        <artifactId>protobuf-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>compile-protoc</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
@@ -203,4 +190,29 @@ limitations under the License.
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>compile-protobuf</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.xolstice.maven.plugins</groupId>
+            <artifactId>protobuf-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>compile-protoc</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/site/develop/index.md
+++ b/site/develop/index.md
@@ -57,6 +57,27 @@ The HOWTO describes how to
 [run more or fewer tests]({{ site.baseurl }}/docs/howto.html#running-tests) and
 [run integration tests]({{ site.baseurl }}/docs/howto.html#running-integration-tests).
 
+### Disabling protobuf generation
+
+On older operating systems, developers trying to build Avatica may experience
+issues with the Xolstice maven-protobuf-plugin, similar to the following:
+
+```
+[INFO] Compiling 3 proto file(s) to /avatica/core/src/main/java
+[ERROR] PROTOC FAILED: /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe)
+[ERROR] /avatica/core/src/main/protobuf/common.proto [0:0]: /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe)
+[ERROR] /avatica/core/src/main/protobuf/responses.proto [0:0]: /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe)
+[ERROR] /avatica/core/src/main/protobuf/requests.proto [0:0]: /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe)
+```
+
+In most cases, it is unnecessary to re-generate the Protobuf messages into Java code. Developers
+can side-step this issue by disabling the `compile-protobuf` profile in their Maven execution.
+
+{% highlight bash %}
+$ mvn package -P!compile-protobuf
+{% endhighlight %}
+
+
 ## Contributing
 
 We welcome contributions.


### PR DESCRIPTION
Protobuf compilation will still run by default, but users can disable it by providing `-P!compile-protobuf`.