### PR TITLE
[CALCITE-2145] Fixed "executeBatchInsertWithDates" test failing on specific local timezones

### DIFF
--- a/server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
@@ -1430,7 +1430,7 @@ public class RemoteDriverTest {
         assertTrue("ResultSet should have a result", rs.next());
         assertEquals("Wrong value for row " + i, Integer.toString(i), rs.getString(1).trim());
 
-        Date actual = rs.getDate(2);
+        Date actual = rs.getDate(2, calendar);
         calendar.setTime(actual);
         int actualDay = calendar.get(Calendar.DAY_OF_MONTH);
         int actualMonth = calendar.get(Calendar.MONTH);


### PR DESCRIPTION
Added missing calendar parameter to getDate method.
Now the test passes also with GMT+2 and GMT+8 (e.g., MAVEN_OPTS="$MAVEN_OPTS -Duser.timezone=GMT+2" mvn clean test), differently from before.