### PR TITLE
[CALCITE-508] wrapping RuntimeException into SQLException in Cursor.Accessor getAccessor method, added unit tests

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaResultSet.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaResultSet.java
@@ -135,7 +135,7 @@ public class AvaticaResultSet extends ArrayFactoryImpl implements ResultSet {
    * @throws SQLException if there is no column with that label
    */
   private Cursor.Accessor getAccessor(String columnLabel) throws SQLException {
-    return accessorList.get(findColumn0(columnLabel));
+    return getAccessor(findColumn0(columnLabel));
   }
 
   public void close() {

--- a/core/src/main/java/org/apache/calcite/avatica/util/IteratorCursor.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/IteratorCursor.java
@@ -68,7 +68,7 @@ public abstract class IteratorCursor<E> extends PositionedCursor<E> {
 
   protected E current() {
     if (position != Position.OK) {
-      throw new NoSuchElementException();
+      throw new NoSuchElementException("Invalid cursor position");
     }
     return current;
   }

--- a/core/src/main/java/org/apache/calcite/avatica/util/PositionedCursor.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/PositionedCursor.java
@@ -48,19 +48,21 @@ public abstract class PositionedCursor<T> extends AbstractCursor {
       this.field = field;
     }
 
-    public Object getObject() {
-      Object collection = current();
+    public Object getObject() throws SQLException {
+      Object collection;
       Object o;
-      if (collection instanceof List) {
-        o = ((List) collection).get(field);
-      } else if (collection instanceof StructImpl) {
-        try {
+      try {
+        collection = current();
+
+        if (collection instanceof List) {
+          o = ((List) collection).get(field);
+        } else if (collection instanceof StructImpl) {
           o = ((StructImpl) collection).getAttributes()[field];
-        } catch (SQLException e) {
-          throw new RuntimeException(e);
+        } else {
+          o = ((Object[]) collection)[field];
         }
-      } else {
-        o = ((Object[]) collection)[field];
+      } catch (RuntimeException e) {
+        throw new SQLException(e);
       }
       wasNull[0] = o == null;
       return o;
@@ -77,8 +79,13 @@ public abstract class PositionedCursor<T> extends AbstractCursor {
       this.index = index;
     }
 
-    public Object getObject() {
-      Object o = ((List) current()).get(index);
+    public Object getObject() throws SQLException {
+      Object o;
+      try {
+        o = ((List) current()).get(index);
+      } catch (RuntimeException e) {
+        throw new SQLException(e);
+      }
       wasNull[0] = o == null;
       return o;
     }
@@ -95,8 +102,13 @@ public abstract class PositionedCursor<T> extends AbstractCursor {
       assert field == 0;
     }
 
-    public Object getObject() {
-      Object o = current();
+    public Object getObject() throws SQLException {
+      Object o;
+      try {
+        o = current();
+      } catch (RuntimeException e) {
+        throw new SQLException(e);
+      }
       wasNull[0] = o == null;
       return o;
     }
@@ -108,16 +120,14 @@ public abstract class PositionedCursor<T> extends AbstractCursor {
   protected class FieldGetter extends AbstractGetter {
     protected final Field field;
 
-    public FieldGetter(Field field) {
-      this.field = field;
-    }
+    public FieldGetter(Field field) { this.field = field; }
 
-    public Object getObject() {
+    public Object getObject() throws SQLException {
       Object o;
       try {
         o = field.get(current());
-      } catch (IllegalAccessException e) {
-        throw new RuntimeException(e);
+      } catch (IllegalAccessException | RuntimeException e) {
+        throw new SQLException(e);
       }
       wasNull[0] = o == null;
       return o;
@@ -134,10 +144,15 @@ public abstract class PositionedCursor<T> extends AbstractCursor {
       this.key = key;
     }
 
-    public Object getObject() {
-      @SuppressWarnings("unchecked") final Map<K, Object> map =
-          (Map<K, Object>) current();
-      Object o = map.get(key);
+    public Object getObject() throws SQLException {
+      @SuppressWarnings("unchecked") final Map<K, Object> map;
+      Object o;
+      try {
+        map = (Map<K, Object>) current();
+        o = map.get(key);
+      } catch (RuntimeException e) {
+        throw new SQLException(e);
+      }
       wasNull[0] = o == null;
       return o;
     }

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetThrowsSqlExceptionTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetThrowsSqlExceptionTest.java
@@ -53,6 +53,21 @@ public class AvaticaResultSetThrowsSqlExceptionTest {
     }
   }
 
+  /**
+   * Auxiliary method returning a result set on a test table.
+   * @return a result set on a test table.
+   * @throws SQLException in case of database error
+   */
+  private ResultSet getResultSet() throws SQLException {
+    Properties properties = new Properties();
+    properties.setProperty("timeZone", "GMT");
+
+    final TestDriver driver = new TestDriver();
+    final Connection connection = driver.connect("jdbc:test", properties);
+
+    return connection.createStatement().executeQuery("SELECT * FROM TABLE");
+  }
+
   @Test
   public void testPrevious() throws SQLException {
     Properties properties = new Properties();
@@ -60,8 +75,8 @@ public class AvaticaResultSetThrowsSqlExceptionTest {
 
     final TestDriver driver = new TestDriver();
     try (Connection connection = driver.connect("jdbc:test", properties);
-         ResultSet resultSet =
-             connection.createStatement().executeQuery("SELECT * FROM TABLE")) {
+       ResultSet resultSet =
+               connection.createStatement().executeQuery("SELECT * FROM TABLE")) {
       thrown.expect(SQLFeatureNotSupportedException.class);
       resultSet.previous();
     }
@@ -75,11 +90,118 @@ public class AvaticaResultSetThrowsSqlExceptionTest {
     final TestDriver driver = new TestDriver();
     try (Connection connection = driver.connect("jdbc:test", properties);
          ResultSet resultSet =
-             connection.createStatement().executeQuery("SELECT * FROM TABLE")) {
+                 connection.createStatement().executeQuery("SELECT * FROM TABLE")) {
       thrown.expect(SQLFeatureNotSupportedException.class);
       resultSet.updateNull(1);
     }
   }
-}
 
+  @Test
+  public void testCommonCursorStates() throws SQLException {
+    final ResultSet resultSet = getResultSet();
+
+    // right after statement execution, result set is before first row
+    assert resultSet.isBeforeFirst();
+
+    // retrieve each row until the last one
+    while (!resultSet.isAfterLast()) {
+      assert resultSet.next() != resultSet.isAfterLast();
+    }
+
+    // result set is not closed yet, despite fully consumed
+    assert !resultSet.isClosed();
+
+    resultSet.close();
+
+    // result set is now closed
+    assert resultSet.isClosed();
+
+    // once closed, next should fail
+    thrown.expect(SQLException.class);
+    resultSet.next();
+  }
+
+  /**
+   * Auxiliary method for testing column access.
+   * @param resultSet the result set
+   * @param index the index of the column to be accessed
+   * @param shouldThrow true iff the column access should throw an exception
+   * @return true iff the method invocation succeeded
+   * @throws SQLException in case of database error
+   */
+  private boolean getColumn(final ResultSet resultSet,
+                            final int index,
+                            final boolean shouldThrow) throws SQLException {
+    try {
+      switch (index) {
+      case 1:
+        resultSet.getBoolean(index);   // BOOLEAN
+        break;
+      case 2:
+        resultSet.getByte(index);      // TINYINT
+        break;
+      case 3:
+        resultSet.getShort(index);     // SMALLINT
+        break;
+      case 4:
+        resultSet.getInt(index);       // INTEGER
+        break;
+      case 5:
+        resultSet.getLong(index);      // BIGINT
+        break;
+      case 6:
+        resultSet.getFloat(index);     // REAL
+        break;
+      case 7:
+        resultSet.getDouble(index);    // FLOAT
+        break;
+      case 8:
+        resultSet.getString(index);    // VARCHAR
+        break;
+      case 9:
+        resultSet.getDate(index);      // DATE
+        break;
+      case 10:
+        resultSet.getTime(index);      // TIME
+        break;
+      case 11:
+        resultSet.getTimestamp(index); // TIMESTAMP
+        break;
+      default:
+        resultSet.getObject(index);
+      }
+    } catch (SQLException e) {
+      if (!shouldThrow) {
+        throw e;
+      }
+      return true;
+    }
+
+    return !shouldThrow;
+  }
+
+  @Test
+  public void testGetColumnsBeforeNext() throws SQLException {
+    try (ResultSet resultSet = getResultSet()) {
+      // we have not called next, so each column getter should throw SQLException
+      for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); i++) {
+        //System.out.println(resultSet.getMetaData().getColumnTypeName(i));
+        assert getColumn(resultSet, i, true);
+      }
+    }
+  }
+
+  @Test
+  public void testGetColumnsAfterNext() throws SQLException {
+    try (ResultSet resultSet = getResultSet()) {
+      // result set is composed by 1 row, we call next before accessing columns
+      resultSet.next();
+
+      // after calling next, column getters should succeed
+      for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
+        assert getColumn(resultSet, i, false);
+      }
+    }
+  }
+}
 // End AvaticaResultSetThrowsSqlExceptionTest.java


### PR DESCRIPTION
The PR in summary:

1) I have basically followed the suggestion of wrapping RuntimeExceptions into SQLException into accessors by handling this into the getObject methods, as consistently invoked under the hood by the accessors themselves.

2) I have added some unit test for checking for error while accessing columns for a cursor not initialized (i.e., next() was never called), and for checking that the same operations were ok after calling next() on the cursor.

3) Minor refactoring of tests in "AvaticaResultSetThrowsSqlExceptionTest.java" by the addition of an auxiliary method.

I still have one doubt:
Line 71 in IteratorCursor.java: throw new NoSuchElementException("Invalid cursor position");
Would it make more sense to directly throw this exception as an instance of SQLException (as it will end up anyway, being a RuntimeException) or not?