### PR TITLE
[CALCITE-2207] Enforce minimum JDK 8 via maven-enforcer-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@ limitations under the License.
     <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>2.12.1</maven-checkstyle-plugin.version>
     <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
     <!-- Apache 18 has 2.10.3, need 2.10.4 for [MJAVADOC-442]. -->
     <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
     <maven-scm-provider.version>1.9.4</maven-scm-provider.version>
@@ -444,6 +445,10 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
+       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
       <plugin>
         <!-- This is the configuration used by "mvn javadoc:javadoc". It is
              configured strict, so that it shows errors such as broken links in
@@ -501,6 +506,26 @@ limitations under the License.
           <!-- override default version 2.8 for access to additional config settings -->
           <artifactId>maven-dependency-plugin</artifactId>
           <version>${maven-dependency-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${maven-enforcer-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>enforce-java</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireJavaVersion>
+                    <version>[1.8,)</version>
+                  </requireJavaVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>


### PR DESCRIPTION
#Tested with JDK 7:
```
mvn --version
Apache Maven 3.5.3 (3383c37e1f9e9b3bc3df5050c29c8aff9f295297; 2018-02-24T13:49:05-06:00)
Maven home: /usr/local/Cellar/maven/3.5.3/libexec
Java version: 1.7.0_80, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.7.0_80.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.3", arch: "x86_64", family: "mac"

mvn clean install -DskipTests
...
[INFO] --- maven-enforcer-plugin:3.0.0-M1:enforce (enforce-java) @ calcite ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireJavaVersion failed with message:
Detected JDK Version: 1.7.0-80 is not in the allowed range [1.8,).
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M1:enforce (enforce-java) on project avatica-parent: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]
...
```

Checked with JDK 8, 9, and 10-ea and build works as designed.