### PR TITLE
[CALCITE-2268] Bump HSQLDB to 2.4.0 in HSQLDB avatica docker image

### DIFF
--- a/docker/src/main/docker/hypersql/Dockerfile
+++ b/docker/src/main/docker/hypersql/Dockerfile
@@ -16,7 +16,7 @@
 FROM avatica-server:latest
 MAINTAINER Apache Avatica <dev@calcite.apache.org>
 
-ARG HSQLDB_VERSION="2.3.1"
+ARG HSQLDB_VERSION="2.4.0"
 
 # Dependencies
 ADD https://repo1.maven.org/maven2/net/hydromatic/scott-data-hsqldb/0.1/scott-data-hsqldb-0.1.jar /home/avatica/classpath/


### PR DESCRIPTION
HSQLDB was updated in the main avatica code, but was not bumped in the docker image.