### PR TITLE
[CALCITE-2255] Add JDK 11 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ language: java
 matrix:
   fast_finish: true
   include:
+    - env: IMAGE=maven:3-jdk-11
     - env: IMAGE=maven:3-jdk-10
-    # Workaround: https://github.com/docker-library/openjdk/issues/145
-    - env: IMAGE=maven:3-jdk-9-slim
+    - env: IMAGE=maven:3-jdk-9
     - env: IMAGE=maven:3-jdk-8
     - env: IMAGE=maven:3-ibmjava-8
 branches:
@@ -41,11 +41,11 @@ before_install:
   - docker pull $IMAGE
 install:
   # Print the Maven version, skip tests and javadoc
-  - $DOCKERRUN $IMAGE mvn -V install -DskipTests -Dmaven.javadoc.skip=true
+  - $DOCKERRUN $IMAGE mvn -V install -DskipTests -Dmaven.javadoc.skip=true -Djavax.net.ssl.trustStorePassword=changeit
 script:
   # Print surefire output to the console instead of files
   - unset _JAVA_OPTIONS
-  - $DOCKERRUN $IMAGE mvn -Dsurefire.useFile=false verify javadoc:javadoc javadoc:test-javadoc
+  - $DOCKERRUN $IMAGE mvn -Dsurefire.useFile=false -Djavax.net.ssl.trustStorePassword=changeit verify javadoc:javadoc javadoc:test-javadoc
 git:
   depth: 10000
 sudo: required


### PR DESCRIPTION
Moved from jdk 9 slim since there is a better way to handle the SSL workaround with truststore password.