### PR TITLE
[CALCITE-1937] Update the avatica website in preparation for avatica-go content

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,2 +1,3 @@
 .sass-cache
 Gemfile.lock
+.jekyll-metadata

--- a/site/Gemfile
+++ b/site/Gemfile
@@ -14,8 +14,11 @@
 # limitations under the License.
 #
 source 'https://rubygems.org'
-gem 'github-pages', '150'
+gem 'github-pages', '182'
 gem 'rouge'
-gem 'jekyll_oembed'
 gem 'jekyll-redirect-from'
+
+group :jekyll_plugins do
+  gem 'jekyll_oembed'
+end
 # End Gemfile

--- a/site/README.md
+++ b/site/README.md
@@ -24,33 +24,63 @@ This directory contains the code for the
 a sub-directory of the
 [Apache Calcite web site](https://calcite.apache.org).
 
-## Setup
+You can build the site manually using your environment or use the docker compose file.
+
+## Manually
+
+### Setup your environment
 
 Similar to the instructions to
-[set up the Calcite web site](../site/README.md).
+[set up the Calcite web site](https://github.com/apache/calcite-avatica/blob/master/site/README.md).
 
-Site generation currently works best with ruby-2.4.1.
+Site generation currently works best with ruby-2.5.1.
 
 1. `cd site`
 2. `svn co https://svn.apache.org/repos/asf/calcite/site/avatica target/avatica`
-3. `sudo apt-get install rubygems ruby2.1-dev zlib1g-dev` (linux)
-4. `sudo gem install bundler github-pages jekyll jekyll-oembed`
-5. `bundle install`
+3. `sudo apt-get install rubygems ruby2.5-dev zlib1g-dev` (linux)
+4. `sudo gem install bundler`
+5. Add avatica-go content: `./add-avatica-go-docs.sh` 
+6. `bundle install`
 
-## Add javadoc
+### Add javadoc
 
 1. `cd avatica`
 2. `mvn -DskipTests site`
 3. `rm -rf site/target/avatica/apidocs site/target/avatica/testapidocs`
 4. `mv target/site/apidocs target/site/testapidocs site/target/avatica`
 
-## Running locally
+### Running locally
 
 Before opening a pull request, you can preview your contributions by
 running from within the directory:
 
 1. `bundle exec jekyll serve`
-2. Open [http://localhost:4000/avatica](http://localhost:4000/avatica)
+2. Open [http://localhost:4000/avatica/](http://localhost:4000/avatica/) (note the trailing slash)
+
+## Using docker
+
+### Setup your environment
+
+1. Install [docker](https://docs.docker.com/install/)
+2. Install [docker-compose](https://docs.docker.com/compose/install/)
+
+### Build site
+1. `cd site`
+2. `docker-compose run build-site`
+
+### Generate javadoc
+1. `cd site`
+2. `docker-compose run generate-javadoc`
+
+### Running development mode locally
+You can preview your work while working on the site.
+
+1. `cd site`
+2. `docker-compose run --service-ports dev`
+
+The web server will be started on [http://localhost:4000/avatica/](http://localhost:4000/avatica/) (note the trailing slash)
+
+As you make changes to the site, the site will automatically rebuild.
 
 ## Pushing to site
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -19,7 +19,7 @@ excerpt_separator: ""
 
 repository: https://github.com/apache/calcite-avatica
 destination: target/avatica
-exclude: [README.md,Gemfile*]
+exclude: [README.md,Gemfile*,add-avatica-go-docs.sh,docker-compose.yml]
 keep_files: [".git", ".svn", "apidocs", "testapidocs"]
 
 collections:

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -26,7 +26,7 @@ limitations under the License.
 For a full list of releases, see
 <a href="https://github.com/apache/calcite-avatica/releases">github</a>.
 Downloads are available on the
-[downloads page]({{ site.baseurl }}/downloads/).
+[downloads page]({{ site.baseurl }}/downloads/avatica.html).
 
 ## <a href="https://github.com/apache/calcite-avatica/releases/tag/calcite-avatica-1.11.0">1.11.0</a> / 2018-03-09
 {: #v1-11-0}

--- a/site/_includes/news_contents.html
+++ b/site/_includes/news_contents.html
@@ -4,15 +4,18 @@
       <li class="{% if page.title == 'News' %}current{% endif %}">
         <a href="{{ site.baseurl }}/news/">All News</a>
       </li>
-      <li class="{% if page.title == 'Releases' %}current{% endif %}">
-        <a href="{{ site.baseurl }}/news/releases/">Avatica Releases</a>
+      <li class="{% if page.title == 'Avatica Releases' %}current{% endif %}">
+        <a href="{{ site.baseurl }}/news/avatica-releases/">Avatica Releases</a>
+      </li>
+      <li class="{% if page.title == 'Avatica Go Releases' %}current{% endif %}">
+          <a href="{{ site.baseurl }}/news/avatica-go-releases/">Avatica Go Releases</a>
       </li>
     </ul>
     <h4>Recent Releases</h4>
     <ul>
       {% for post in site.categories.release limit:5 %}
       <li class="{% if page.title == post.title %}current{% endif %}">
-        <a href="{{ site.baseurl }}{{ post.url }}">{{ post.version }}</a>
+        <a href="{{ site.baseurl }}{{ post.url }}">{{post.component}} {{ post.version }}</a>
       </li>
       {% endfor %}
     </ul>

--- a/site/_includes/news_item.html
+++ b/site/_includes/news_item.html
@@ -55,8 +55,13 @@ limitations under the License.
   <div class="post-content">
     {{ post.content }}
     {% if post.categories contains 'release' %}
-    <p>See the <a href="{{ site.baseurl }}/docs/history.html#{{ post.tag }}">release notes</a>;
-      <a href="{{ site.baseurl }}/downloads#source-releases">download</a> the release.</p>
+        {% if post.component == 'avatica-go' %}
+        <p>See the <a href="{{ site.baseurl }}/docs/go_history.html#{{ page.tag }}">release notes</a>;
+            <a href="{{ site.baseurl }}/downloads/avatica-go.html#source-releases">download</a> the release.</p>
+        {% else %}
+        <p>See the <a href="{{ site.baseurl }}/docs/history.html#{{ page.tag }}">release notes</a>;
+            <a href="{{ site.baseurl }}/downloads/avatica.html#source-releases">download</a> the release.</p>
+        {% endif %}
     {% endif %}
   </div>
 </article>

--- a/site/_layouts/news_item.html
+++ b/site/_layouts/news_item.html
@@ -42,8 +42,13 @@ layout: news
   <div class="post-content">
     {{ content }}
     {% if page.categories contains 'release' %}
-    <p>See the <a href="{{ site.baseurl }}/docs/history.html#{{ page.tag }}">release notes</a>;
-      <a href="{{ site.baseurl }}/downloads#source-releases">download</a> the release.</p>
+      {% if page.categories contains 'avatica-go' %}
+        <p>See the <a href="{{ site.baseurl }}/docs/go_history.html#{{ page.tag }}">release notes</a>;
+            <a href="{{ site.baseurl }}/downloads/avatica-go.html#source-releases">download</a> the release.</p>
+      {% else %}
+        <p>See the <a href="{{ site.baseurl }}/docs/history.html#{{ page.tag }}">release notes</a>;
+            <a href="{{ site.baseurl }}/downloads/avatica.html#source-releases">download</a> the release.</p>
+      {% endif %}
     {% endif %}
   </div>
 </article>

--- a/site/_posts/2016-03-03-separate-project.md
+++ b/site/_posts/2016-03-03-separate-project.md
@@ -4,6 +4,7 @@ title: "Splitting Avatica from Calcite"
 date: "2016-03-03 23:57:33 -0500"
 author: elserj
 categories: [milestones]
+component: avatica
 ---
 <!--
 {% comment %}

--- a/site/_posts/2016-03-18-release-1.7.1.md
+++ b/site/_posts/2016-03-18-release-1.7.1.md
@@ -6,6 +6,7 @@ version: 1.7.1
 categories: [release]
 tag: v1-7-1
 sha: 11cb0a8
+component: avatica
 ---
 <!--
 {% comment %}

--- a/site/_posts/2016-06-04-release-1.8.0.md
+++ b/site/_posts/2016-06-04-release-1.8.0.md
@@ -6,6 +6,7 @@ version: 1.8.0
 categories: [release]
 tag: v1-8-0
 sha: ddfaf07
+component: avatica
 ---
 <!--
 {% comment %}

--- a/site/_posts/2016-11-01-release-1.9.0.md
+++ b/site/_posts/2016-11-01-release-1.9.0.md
@@ -6,6 +6,7 @@ version: 1.9.0
 categories: [release]
 tag: v1-9-0
 sha: e32d778
+component: avatica
 ---
 <!--
 {% comment %}

--- a/site/_posts/2017-03-31-new-avatica-repository.md
+++ b/site/_posts/2017-03-31-new-avatica-repository.md
@@ -3,6 +3,7 @@ layout: news_item
 date: "2017-03-31 17:00:00 +0000"
 author: elserj
 categories: [milestones]
+component: avatica
 ---
 <!--
 {% comment %}

--- a/site/_posts/2017-05-30-release-1.10.0.md
+++ b/site/_posts/2017-05-30-release-1.10.0.md
@@ -6,6 +6,7 @@ version: 1.10.0
 categories: [release]
 tag: v1-10-0
 sha: fcec4be
+component: avatica
 ---
 <!--
 {% comment %}

--- a/site/_posts/2018-03-09-release-1.11.0.md
+++ b/site/_posts/2018-03-09-release-1.11.0.md
@@ -6,6 +6,7 @@ version: 1.11.0
 categories: [release]
 tag: v1-11-0
 sha: e533391
+component: avatica
 ---
 <!--
 {% comment %}

--- a/site/add-avatica-go-docs.sh
+++ b/site/add-avatica-go-docs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+git clone https://github.com/apache/calcite-avatica-go /tmp/calcite-avatica-go
+
+cp /tmp/calcite-avatica-go/site/_docs/* _docs/
+cp /tmp/calcite-avatica-go/site/_posts/* _posts/
+cp /tmp/calcite-avatica-go/site/develop/* develop/

--- a/site/develop/avatica.md
+++ b/site/develop/avatica.md
@@ -1,0 +1,138 @@
+---
+layout: page
+title: Developing Avatica
+permalink: /develop/avatica.html
+---
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+Want to help add a feature or fix a bug?
+
+* TOC
+{:toc}
+
+## Source code
+
+You can get the source code by
+[downloading a release]({{ site.baseurl }}/downloads)
+or from source control.
+
+Calcite uses git for version control.  The canonical source is in
+[Apache](https://git-wip-us.apache.org/repos/asf/calcite.git),
+but most people find the
+[Github mirror](https://github.com/apache/calcite-avatica) more
+user-friendly.
+
+## Download source, build, and run tests
+
+Prerequisites are git, maven (3.2.1 or later) and Java (JDK 1.8 or
+later, 1.9 preferred) on your path.
+
+Create a local copy of the git repository, `cd` to its root directory,
+then build using maven:
+
+{% highlight bash %}
+$ git clone git://github.com/apache/calcite-avatica.git avatica
+$ cd avatica
+$ mvn install
+{% endhighlight %}
+
+The HOWTO describes how to
+[build from a source distribution]({{ site.baseurl }}/docs/howto.html#building-from-a-source-distribution),
+[run more or fewer tests]({{ site.baseurl }}/docs/howto.html#running-tests) and
+[run integration tests]({{ site.baseurl }}/docs/howto.html#running-integration-tests).
+
+### Disabling protobuf generation
+
+On older operating systems, developers trying to build Avatica may experience
+issues with the Xolstice maven-protobuf-plugin, similar to the following:
+
+```
+[INFO] Compiling 3 proto file(s) to /avatica/core/src/main/java
+[ERROR] PROTOC FAILED: /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe)
+[ERROR] /avatica/core/src/main/protobuf/common.proto [0:0]: /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe)
+[ERROR] /avatica/core/src/main/protobuf/responses.proto [0:0]: /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe)
+[ERROR] /avatica/core/src/main/protobuf/requests.proto [0:0]: /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe)
+```
+
+In most cases, it is unnecessary to re-generate the Protobuf messages into Java code. Developers
+can side-step this issue by disabling the `compile-protobuf` profile in their Maven execution.
+
+{% highlight bash %}
+$ mvn package -P!compile-protobuf
+{% endhighlight %}
+
+
+## Contributing
+
+We welcome contributions.
+
+If you are planning to make a large contribution, talk to us first! It
+helps to agree on the general approach. Log a
+[JIRA case](https://issues.apache.org/jira/browse/CALCITE) for your
+proposed feature or start a discussion on the dev list.
+
+Fork the github repository, and create a branch for your feature.
+
+Develop your feature and test cases, and make sure that
+`mvn install` succeeds. (Run extra tests if your change warrants it.)
+
+Commit your change to your branch, and use a comment that starts with
+the JIRA case number, like this:
+
+{% highlight text %}
+[CALCITE-345] AssertionError in RexToLixTranslator comparing to date literal
+{% endhighlight %}
+
+If your change had multiple commits, use `git rebase -i master` to
+squash them into a single commit, and to bring your code up to date
+with the latest on the main line.
+
+Then push your commit(s) to github, and create a pull request from
+your branch to the calcite master branch. Update the JIRA case
+to reference your pull request, and a committer will review your
+changes.
+
+## Continuous Integration Testing
+
+Calcite has a collection of Jenkins jobs on ASF-hosted infrastructure.
+They are all organized in a single view and available at
+[https://builds.apache.org/view/A-D/view/Calcite-Avatica/](https://builds.apache.org/view/A-D/view/Calcite-Avatica/).
+
+## Getting started
+
+Calcite is a community, so the first step to joining the project is to introduce yourself.
+Join the [developers list](http://mail-archives.apache.org/mod_mbox/calcite-dev/)
+and send an email.
+
+If you have the chance to attend a [meetup](http://www.meetup.com/Apache-Calcite/),
+or meet [members of the community](http://calcite.apache.org/develop/#project-members)
+at a conference, that's also great.
+
+Choose an initial task to work on. It should be something really simple,
+such as a bug fix or a [Jira task that we have labeled
+"newbie"](https://issues.apache.org/jira/issues/?jql=labels%20%3D%20newbie%20%26%20project%20%3D%20Calcite%20%26%20status%20%3D%20Open).
+Follow the [contributing guidelines](#contributing) to get your change committed.
+
+After you have made several useful contributions we may
+[invite you to become a committer](https://community.apache.org/contributors/).
+We value all contributions that help to build a vibrant community, not just code.
+You can contribute by testing the code, helping verify a release,
+writing documentation or the web site,
+or just by answering questions on the list.

--- a/site/develop/index.md
+++ b/site/develop/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Developing Calcite
+title: Developing Avatica Components
 ---
 <!--
 {% comment %}
@@ -23,115 +23,9 @@ limitations under the License.
 
 Want to help add a feature or fix a bug?
 
-* TOC
-{:toc}
+Please find the development guides for Avatica's components here:
 
-## Source code
-
-You can get the source code by
-[downloading a release]({{ site.baseurl }}/downloads)
-or from source control.
-
-Calcite uses git for version control.  The canonical source is in
-[Apache](https://git-wip-us.apache.org/repos/asf/calcite.git),
-but most people find the
-[Github mirror](https://github.com/apache/calcite-avatica) more
-user-friendly.
-
-## Download source, build, and run tests
-
-Prerequisites are git, maven (3.2.1 or later) and Java (JDK 1.7 or
-later, 1.8 preferred) on your path.
-
-Create a local copy of the git repository, `cd` to its root directory,
-then build using maven:
-
-{% highlight bash %}
-$ git clone git://github.com/apache/calcite-avatica.git avatica
-$ cd avatica
-$ mvn install
-{% endhighlight %}
-
-The HOWTO describes how to
-[build from a source distribution]({{ site.baseurl }}/docs/howto.html#building-from-a-source-distribution),
-[run more or fewer tests]({{ site.baseurl }}/docs/howto.html#running-tests) and
-[run integration tests]({{ site.baseurl }}/docs/howto.html#running-integration-tests).
-
-### Disabling protobuf generation
-
-On older operating systems, developers trying to build Avatica may experience
-issues with the Xolstice maven-protobuf-plugin, similar to the following:
-
-```
-[INFO] Compiling 3 proto file(s) to /avatica/core/src/main/java
-[ERROR] PROTOC FAILED: /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe)
-[ERROR] /avatica/core/src/main/protobuf/common.proto [0:0]: /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe)
-[ERROR] /avatica/core/src/main/protobuf/responses.proto [0:0]: /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe)
-[ERROR] /avatica/core/src/main/protobuf/requests.proto [0:0]: /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /avatica/core/target/protoc-plugins/protoc-3.1.0-linux-x86_64.exe)
-```
-
-In most cases, it is unnecessary to re-generate the Protobuf messages into Java code. Developers
-can side-step this issue by disabling the `compile-protobuf` profile in their Maven execution.
-
-{% highlight bash %}
-$ mvn package -P!compile-protobuf
-{% endhighlight %}
-
-
-## Contributing
-
-We welcome contributions.
-
-If you are planning to make a large contribution, talk to us first! It
-helps to agree on the general approach. Log a
-[JIRA case](https://issues.apache.org/jira/browse/CALCITE) for your
-proposed feature or start a discussion on the dev list.
-
-Fork the github repository, and create a branch for your feature.
-
-Develop your feature and test cases, and make sure that
-`mvn install` succeeds. (Run extra tests if your change warrants it.)
-
-Commit your change to your branch, and use a comment that starts with
-the JIRA case number, like this:
-
-{% highlight text %}
-[CALCITE-345] AssertionError in RexToLixTranslator comparing to date literal
-{% endhighlight %}
-
-If your change had multiple commits, use `git rebase -i master` to
-squash them into a single commit, and to bring your code up to date
-with the latest on the main line.
-
-Then push your commit(s) to github, and create a pull request from
-your branch to the calcite master branch. Update the JIRA case
-to reference your pull request, and a committer will review your
-changes.
-
-## Continuous Integration Testing
-
-Calcite has a collection of Jenkins jobs on ASF-hosted infrastructure.
-They are all organized in a single view and available at
-[https://builds.apache.org/view/A-D/view/Calcite-Avatica/](https://builds.apache.org/view/A-D/view/Calcite-Avatica/).
-
-## Getting started
-
-Calcite is a community, so the first step to joining the project is to introduce yourself.
-Join the [developers list](http://mail-archives.apache.org/mod_mbox/calcite-dev/)
-and send an email.
-
-If you have the chance to attend a [meetup](http://www.meetup.com/Apache-Calcite/),
-or meet [members of the community](http://calcite.apache.org/develop/#project-members)
-at a conference, that's also great.
-
-Choose an initial task to work on. It should be something really simple,
-such as a bug fix or a [Jira task that we have labeled
-"newbie"](https://issues.apache.org/jira/issues/?jql=labels%20%3D%20newbie%20%26%20project%20%3D%20Calcite%20%26%20status%20%3D%20Open).
-Follow the [contributing guidelines](#contributing) to get your change committed.
-
-After you have made several useful contributions we may
-[invite you to become a committer](https://community.apache.org/contributors/).
-We value all contributions that help to build a vibrant community, not just code.
-You can contribute by testing the code, helping verify a release,
-writing documentation or the web site,
-or just by answering questions on the list.
+Component         | Guide
+:---------------- | :-----------------------------------
+Avatica           | [Development Guide]({{ site.baseurl }}/develop/avatica.html)
+Avatica Go Client | [Development Guide]({{ site.baseurl }}/develop/avatica-go.html)

--- a/site/docker-compose.yml
+++ b/site/docker-compose.yml
@@ -12,37 +12,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Data that defines menu structure
-#
-- title: Overview
-  docs:
-  - index
-  - roadmap
 
-- title: Avatica Reference
-  docs:
-  - client_reference
-  - json_reference
-  - protobuf_reference
-  - howto
-  - security
-  - compatibility
-  - custom_client_artifacts
-  - docker
-  - protocol_testing
-
-- title: Avatica Go Client Reference
-  docs:
-  - go_client_reference
-
-- title: Avatica Meta
-  docs:
-  - history
-  - api
-  - testapi
-
-- title: Avatica Go Client Meta
-  docs:
-  - go_history
-# End docs.yml
+version: '3'
+services:
+  dev:
+    image: jekyll/jekyll:3
+    command: sh -c "./add-avatica-go-docs.sh; jekyll serve --watch --force_polling"
+    ports:
+      - 4000:4000
+    volumes:
+      - .:/srv/jekyll
+  build-site:
+    image: jekyll/jekyll:3
+    command: sh -c "./add-avatica-go-docs.sh; jekyll build"
+    volumes:
+      - .:/srv/jekyll
+  generate-javadoc:
+    image: maven:alpine
+    working_dir: /usr/src/calcite-avatica
+    command: sh -c "mvn -DskipTests -P!compile-protobuf site; rm -rf site/target/avatica/apidocs site/target/avatica/testapidocs; mkdir -p site/target/avatica; mv target/site/apidocs target/site/testapidocs site/target/avatica"
+    volumes:
+      - ../:/usr/src/calcite-avatica
+      - maven-repo:/root/.m2
+volumes:
+  maven-repo:

--- a/site/downloads/avatica-go.md
+++ b/site/downloads/avatica-go.md
@@ -1,0 +1,85 @@
+---
+layout: page
+title: Avatica Go Client Downloads
+permalink: /downloads/avatica-go.html
+---
+
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+## Source releases
+
+Release          | Date       | Commit   | Download
+:--------------- | :--------- | :------- | :-------
+{% for post in site.categories.release %}{% comment %}
+{% endcomment %}{% if post.component != "avatica-go" %}{% comment %}
+{% endcomment %}{% continue %}{% comment %}
+{% endcomment %}{% endif %}{% comment %}
+{% endcomment %}{% if post.fullVersion %}{% comment %}
+{% endcomment %}{% assign v = post.fullVersion %}{% comment %}
+{% endcomment %}{% else %}{% comment %}
+{% endcomment %}{% capture v %}apache-calcite-avatica-go{{ post.version }}{% endcapture %}{% comment %}
+{% endcomment %}{% endif %}{% comment %}
+{% endcomment %}{% if forloop.index0 < 1 %}{% comment %}
+{% endcomment %}{% capture p %}http://www.apache.org/dyn/closer.lua?filename=calcite/{{ v }}{% endcapture %}{% comment %}
+{% endcomment %}{% assign q = "&action=download" %}{% comment %}
+{% endcomment %}{% assign d = "https://www.apache.org/dist" %}{% comment %}
+{% endcomment %}{% else %}{% comment %}
+{% endcomment %}{% capture p %}http://archive.apache.org/dist/calcite/{{ v }}{% endcapture %}{% comment %}
+{% endcomment %}{% assign q = "" %}{% comment %}
+{% endcomment %}{% assign d = "https://archive.apache.org/dist" %}{% comment %}
+{% endcomment %}{% endif %}{% comment %}
+{% endcomment %}{% capture d1 %}{{ post.date | date: "%F"}}{% endcapture %}{% comment %}
+{% endcomment %}{% capture d2 %}2017-05-01{% endcapture %}{% comment %}
+{% endcomment %}{% capture d3 %}2018-03-01{% endcapture %}{% comment %}
+{% endcomment %}{% if d1 > d3 %}{% comment %}
+{% endcomment %}{% assign digest = "sha256" %}{% comment %}
+{% endcomment %}{% elsif d1 > d2 %}{% comment %}
+{% endcomment %}{% assign digest = "mds" %}{% comment %}
+{% endcomment %}{% else %}{% comment %}
+{% endcomment %}{% assign digest = "md5" %}{% comment %}
+{% endcomment %}{% endif %}{% comment %}
+{% endcomment %}<a href="{{ site.baseurl }}/docs/history.html#{{ post.tag }}">{{ post.version }}</a>{% comment %}
+{% endcomment %} | {{ post.date | date_to_string }}{% comment %}
+{% endcomment %} | <a href="https://github.com/apache/calcite-avatica-go/commit/{{ post.sha }}">{{ post.sha }}</a>{% comment %}
+{% endcomment %} | <a href="{{ p }}/{{ v }}-src.tar.gz{{ q }}">tar</a>{% comment %}
+{% endcomment %} (<a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.tar.gz.{{ digest }}">{{ digest }}</a>{% comment %}
+{% endcomment %} <a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.tar.gz.asc">pgp</a>){% comment %}
+{% endcomment %} {% raw %}<br>{% endraw %}{% comment %}
+{% endcomment %} <a href="{{ p }}/{{ v }}-src.zip{{ q }}">zip</a>{% comment %}
+{% endcomment %} (<a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.zip.{{ digest }}">{{ digest }}</a>{% comment %}
+{% endcomment %} <a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.zip.asc">pgp</a>){% comment %}
+{% endcomment %}
+{% endfor %}
+
+Choose a source distribution in either *tar* or *zip* format,
+and [verify](http://www.apache.org/dyn/closer.cgi#verify)
+using the corresponding *pgp* signature (using the committer file in
+[KEYS](http://www.apache.org/dist/calcite/KEYS)).
+If you cannot do that, use the *sha256* hash file (*md5* in older
+releases) to check that the download has completed OK.
+
+For fast downloads, current source distributions are hosted on mirror servers;
+older source distributions are in the
+[archive](http://archive.apache.org/dist/calcite/).
+If a download from a mirror fails, retry, and the second download will likely
+succeed.
+
+For security, hash and signature files are always hosted at
+[Apache](https://www.apache.org/dist).

--- a/site/downloads/avatica.md
+++ b/site/downloads/avatica.md
@@ -1,0 +1,127 @@
+---
+layout: page
+title: Avatica Downloads
+permalink: /downloads/avatica.html
+---
+
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+Avatica is released as a source artifact, and also through Maven and Docker Hub.
+
+# Source releases
+
+Release          | Date       | Commit   | Download
+:--------------- | :--------- | :------- | :-------
+{% for post in site.categories.release %}{% comment %}
+{% endcomment %}{% if post.component != "avatica" %}{% comment %}
+{% endcomment %}{% continue %}{% comment %}
+{% endcomment %}{% endif %}{% comment %}
+{% endcomment %}{% if post.fullVersion %}{% comment %}
+{% endcomment %}{% assign v = post.fullVersion %}{% comment %}
+{% endcomment %}{% else %}{% comment %}
+{% endcomment %}{% capture v %}apache-calcite-avatica-{{ post.version }}{% endcapture %}{% comment %}
+{% endcomment %}{% endif %}{% comment %}
+{% endcomment %}{% if forloop.index0 < 1 %}{% comment %}
+{% endcomment %}{% capture p %}http://www.apache.org/dyn/closer.lua?filename=calcite/{{ v }}{% endcapture %}{% comment %}
+{% endcomment %}{% assign q = "&action=download" %}{% comment %}
+{% endcomment %}{% assign d = "https://www.apache.org/dist" %}{% comment %}
+{% endcomment %}{% else %}{% comment %}
+{% endcomment %}{% capture p %}http://archive.apache.org/dist/calcite/{{ v }}{% endcapture %}{% comment %}
+{% endcomment %}{% assign q = "" %}{% comment %}
+{% endcomment %}{% assign d = "https://archive.apache.org/dist" %}{% comment %}
+{% endcomment %}{% endif %}{% comment %}
+{% endcomment %}{% capture d1 %}{{ post.date | date: "%F"}}{% endcapture %}{% comment %}
+{% endcomment %}{% capture d2 %}2017-05-01{% endcapture %}{% comment %}
+{% endcomment %}{% capture d3 %}2018-03-01{% endcapture %}{% comment %}
+{% endcomment %}{% if d1 > d3 %}{% comment %}
+{% endcomment %}{% assign digest = "sha256" %}{% comment %}
+{% endcomment %}{% elsif d1 > d2 %}{% comment %}
+{% endcomment %}{% assign digest = "mds" %}{% comment %}
+{% endcomment %}{% else %}{% comment %}
+{% endcomment %}{% assign digest = "md5" %}{% comment %}
+{% endcomment %}{% endif %}{% comment %}
+{% endcomment %}<a href="{{ site.baseurl }}/docs/history.html#{{ post.tag }}">{{ post.version }}</a>{% comment %}
+{% endcomment %} | {{ post.date | date_to_string }}{% comment %}
+{% endcomment %} | <a href="https://github.com/apache/calcite-avatica/commit/{{ post.sha }}">{{ post.sha }}</a>{% comment %}
+{% endcomment %} | <a href="{{ p }}/{{ v }}-src.tar.gz{{ q }}">tar</a>{% comment %}
+{% endcomment %} (<a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.tar.gz.{{ digest }}">{{ digest }}</a>{% comment %}
+{% endcomment %} <a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.tar.gz.asc">pgp</a>){% comment %}
+{% endcomment %} {% raw %}<br>{% endraw %}{% comment %}
+{% endcomment %} <a href="{{ p }}/{{ v }}-src.zip{{ q }}">zip</a>{% comment %}
+{% endcomment %} (<a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.zip.{{ digest }}">{{ digest }}</a>{% comment %}
+{% endcomment %} <a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.zip.asc">pgp</a>){% comment %}
+{% endcomment %}
+{% endfor %}
+
+Choose a source distribution in either *tar* or *zip* format,
+and [verify](http://www.apache.org/dyn/closer.cgi#verify)
+using the corresponding *pgp* signature (using the committer file in
+[KEYS](http://www.apache.org/dist/calcite/KEYS)).
+If you cannot do that, use the *sha256* hash file (*md5* in older
+releases) to check that the download has completed OK.
+
+For fast downloads, current source distributions are hosted on mirror servers;
+older source distributions are in the
+[archive](http://archive.apache.org/dist/calcite/).
+If a download from a mirror fails, retry, and the second download will likely
+succeed.
+
+For security, hash and signature files are always hosted at
+[Apache](https://www.apache.org/dist).
+
+# Maven artifacts
+
+Add the following to the dependencies section of your `pom.xml` file:
+
+{% for post in site.categories.release limit:1 %}
+{% assign current_release = post %}
+{% endfor %}
+
+{% highlight xml %}
+<dependencies>
+  <dependency>
+    <groupId>org.apache.calcite.avatica</groupId>
+    <artifactId>avatica</artifactId>
+    <version>{{ current_release.version }}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.calcite.avatica</groupId>
+    <artifactId>avatica-server</artifactId>
+    <version>{{ current_release.version }}</version>
+  </dependency>
+</dependencies>
+{% endhighlight %}
+
+As of Apache Calcite Avatica 1.9.0, the following un-shaded client artifact is also available:
+
+{% highlight xml %}
+<dependencies>
+  <dependency>
+    <groupId>org.apache.calcite.avatica</groupId>
+    <artifactId>avatica-core</artifactId>
+    <version>{{ current_release.version }}</version>
+  </dependency>
+</dependencies>
+{% endhighlight %}
+
+# Docker images
+
+From release 1.10.0 onwards, Docker images for Avatica Server are available at
+[Docker Hub](https://hub.docker.com/r/apache/calcite-avatica).

--- a/site/index.html
+++ b/site/index.html
@@ -46,7 +46,8 @@ limitations under the License.
         <h3>Resources</h3>
         <ul>
           <li><a href="{{ site.baseurl }}/downloads">Downloads</a></li>
-          <li><a href="{{ site.baseurl }}/docs/history.html">History</a></li>
+          <li><a href="{{ site.baseurl }}/docs/history.html">Avatica History</a></li>
+          <li><a href="{{ site.baseurl }}/docs/go_history.html">Avatica Go Client History</a></li>
           <li><a href="http://www.apache.org/security">Security</a></li>
         </ul>
       </summary>

--- a/site/news/avatica-go-releases/index.html
+++ b/site/news/avatica-go-releases/index.html
@@ -1,8 +1,9 @@
 ---
-layout: page
-title: Avatica Downloads
+layout: news
+title: Avatica Go Releases
+permalink: /news/avatica-go-releases/
+author: all
 ---
-
 <!--
 {% comment %}
 Licensed to the Apache Software Foundation (ASF) under one or more
@@ -22,9 +23,8 @@ limitations under the License.
 {% endcomment %}
 -->
 
-The following downloads are available from the Avatica project:
-
-Component         | Download
-:---------------- | :-----------------------------------
-Avatica           | [Source and binaries]({{ site.baseurl }}/downloads/avatica.html)
-Avatica Go Client | [Source]({{ site.baseurl }}/downloads/avatica-go.html)
+{% for post in site.categories.release %}
+  {% if post.component == 'avatica-go' %}
+    {% include news_item.html %}
+  {% endif %}
+{% endfor %}

--- a/site/news/avatica-releases/index.html
+++ b/site/news/avatica-releases/index.html
@@ -1,8 +1,9 @@
 ---
-layout: page
-title: Avatica Downloads
+layout: news
+title: Avatica Releases
+permalink: /news/avatica-releases/
+author: all
 ---
-
 <!--
 {% comment %}
 Licensed to the Apache Software Foundation (ASF) under one or more
@@ -22,9 +23,8 @@ limitations under the License.
 {% endcomment %}
 -->
 
-The following downloads are available from the Avatica project:
-
-Component         | Download
-:---------------- | :-----------------------------------
-Avatica           | [Source and binaries]({{ site.baseurl }}/downloads/avatica.html)
-Avatica Go Client | [Source]({{ site.baseurl }}/downloads/avatica-go.html)
+{% for post in site.categories.release %}
+  {% if post.component == 'avatica' %}
+    {% include news_item.html %}
+  {% endif %}
+{% endfor %}

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -4,6 +4,7 @@ title: News
 permalink: /news/
 author: all
 ---
+<!--
 {% comment %}
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
@@ -20,6 +21,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 {% endcomment %}
+-->
 
 {% for post in site.posts %}
   {% include news_item.html %}

--- a/site/news/releases/index.html
+++ b/site/news/releases/index.html
@@ -1,9 +1,10 @@
 ---
-layout: news
-title: Releases
-permalink: /news/releases/
-author: all
+layout: page
+title: Avatica Releases
+redirect_to: https://calcite.apache.org/avatica/news/avatica-releases/
 ---
+
+<!--
 {% comment %}
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
@@ -20,7 +21,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 {% endcomment %}
-
-{% for post in site.categories.release %}
-  {% include news_item.html %}
-{% endfor %}
+-->


### PR DESCRIPTION
This PR updates the website in preparation for the release of Avatica-Go 3.0.0 later today.

Similar to https://github.com/apache/calcite/pull/677, I have added a docker-compose file to ease development of the website.

In terms of the website itself, I've reshuffled some of the content and added/updated some pages so that content from Avatica-Go fits properly.

`add-avatica-go-docs.sh` pulls in the avatica-go content by cloning the repository and copying the files to the appropriate locations under `site`. I tried using symlinks, but jekyll does not build them (I think this might be due to using Docker for Windows). The downside of pulling the content in is that it dirties the working tree when building the site. It's possible to do a `git reset` after pushing the website, and it's currently not a huge issue. However, if it does become troublesome in the future, we should look to see if there's a better approach.

pinging @joshelser @julianhyde @michaelmior @risdenk 