### PR TITLE
[CALCITE-2289] Enable html5 for Javadoc on JDK 9+

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaSpecificDatabaseMetaData.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaSpecificDatabaseMetaData.java
@@ -31,7 +31,8 @@ import java.util.Properties;
  *
  * <p>Some properties defined in {@link org.apache.calcite.avatica.Meta.DatabaseProperty} do not
  * correspond to a typical JDBC method/property. Those are enumerated here:
- * <table summary="Avatica-Specific Properties">
+ * <table>
+ *   <caption>"Avatica-Specific Properties"</caption>
  *   <tr><th>Property</th><th>Method</th></tr>
  *   <tr><td>AVATICA_VERSION</td><td>getAvaticaServerVersion()</td></tr>
  * </table>

--- a/core/src/main/java/org/apache/calcite/avatica/SqlType.java
+++ b/core/src/main/java/org/apache/calcite/avatica/SqlType.java
@@ -193,7 +193,7 @@ import java.util.Map;
  * java.util.Date       TIMESTAMP
  * </pre>
  *
- * <p><a name="B5">TABLE B-5</a>: Conversions performed by {@code setObject} and
+ * <p><a id="B5">TABLE B-5</a>: Conversions performed by {@code setObject} and
  * {@code setNull} between Java object types and target JDBC types
  *
  * <!--
@@ -242,7 +242,7 @@ import java.util.Map;
  * CHECKSTYLE: ON
  * -->
  *
- * <p><a name="B6">TABLE B-6</a>: Use of {@code ResultSet} getter methods to
+ * <p><a id="B6">TABLE B-6</a>: Use of {@code ResultSet} getter methods to
  * retrieve JDBC data types
  *
  * <!--

--- a/core/src/main/java/org/apache/calcite/avatica/util/Base64.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/Base64.java
@@ -31,7 +31,7 @@ import java.util.Locale;
  * <br>
  * <code>byte[] myByteArray = Base64.decode( encoded );</code>
  *
- * <p>The <tt>options</tt> parameter, which appears in a few places, is used to pass
+ * <p>The <code>options</code> parameter, which appears in a few places, is used to pass
  * several pieces of information to the encoder. In the "higher level" methods such as
  * encodeBytes( bytes, options ) the options parameter can be used to indicate such
  * things as first gzipping the bytes before encoding them, not inserting linefeeds,
@@ -139,9 +139,9 @@ import java.util.Locale;
  *   when data that's being decoded is gzip-compressed and will decompress it
  *   automatically. Generally things are cleaner. You'll probably have to
  *   change some method calls that you were making to support the new
- *   options format (<tt>int</tt>s that you "OR" together).</li>
+ *   options format (<code>int</code>s that you "OR" together).</li>
  *  <li>v1.5.1 - Fixed bug when decompressing and decoding to a
- *   byte[] using <tt>decode( String s, boolean gzipCompressed )</tt>.
+ *   byte[] using <code>decode( String s, boolean gzipCompressed )</code>.
  *   Added the ability to "suspend" encoding in the Output Stream so
  *   you can turn on and off the encoding if you need to embed base64
  *   data in an otherwise "normal" stream (like an XML file).</li>
@@ -1258,7 +1258,7 @@ public class Base64
    * @param options encode options such as URL_SAFE
    * @return the decoded data
    * @throws java.io.IOException if there is an error
-   * @throws NullPointerException if <tt>s</tt> is null
+   * @throws NullPointerException if <code>s</code> is null
    * @since 1.4
    */
   public static byte[] decode( String s, int options ) throws java.io.IOException {
@@ -1325,7 +1325,7 @@ public class Base64
 
   /**
    * Attempts to decode Base64 data and deserialize a Java
-   * Object within. Returns <tt>null</tt> if there was an error.
+   * Object within. Returns <code>null</code> if there was an error.
    *
    * @param encodedObject The Base64 data to decode
    * @return The decoded and deserialized object
@@ -1343,8 +1343,8 @@ public class Base64
 
   /**
    * Attempts to decode Base64 data and deserialize a Java
-   * Object within. Returns <tt>null</tt> if there was an error.
-   * If <tt>loader</tt> is not null, it will be the class loader
+   * Object within. Returns <code>null</code> if there was an error.
+   * If <code>loader</code> is not null, it will be the class loader
    * used when deserializing.
    *
    * @param encodedObject The Base64 data to decode
@@ -1595,7 +1595,7 @@ public class Base64
   }   // end encodeFromFile
 
   /**
-   * Reads <tt>infile</tt> and encodes it to <tt>outfile</tt>.
+   * Reads <code>infile</code> and encodes it to <code>outfile</code>.
    *
    * @param infile Input file
    * @param outfile Output file
@@ -1623,7 +1623,7 @@ public class Base64
 
 
   /**
-   * Reads <tt>infile</tt> and decodes it to <tt>outfile</tt>.
+   * Reads <code>infile</code> and decodes it to <code>outfile</code>.
    *
    * @param infile Input file
    * @param outfile Output file
@@ -1656,7 +1656,7 @@ public class Base64
 
   /**
    * A {@link Base64.InputStream} will read data from another
-   * <tt>java.io.InputStream</tt>, given in the constructor,
+   * <code>java.io.InputStream</code>, given in the constructor,
    * and encode/decode to/from Base64 notation on the fly.
    *
    * @see Base64
@@ -1678,7 +1678,7 @@ public class Base64
     /**
      * Constructs a {@link Base64.InputStream} in DECODE mode.
      *
-     * @param in the <tt>java.io.InputStream</tt> from which to read data.
+     * @param in the <code>java.io.InputStream</code> from which to read data.
      * @since 1.3
      */
     public InputStream( java.io.InputStream in ) {
@@ -1699,7 +1699,7 @@ public class Base64
      * Example: <code>new Base64.InputStream( in, Base64.DECODE )</code>
      *
      *
-     * @param in the <tt>java.io.InputStream</tt> from which to read data.
+     * @param in the <code>java.io.InputStream</code> from which to read data.
      * @param options Specified options
      * @see Base64#ENCODE
      * @see Base64#DECODE
@@ -1869,7 +1869,7 @@ public class Base64
 
   /**
    * A {@link Base64.OutputStream} will write data to another
-   * <tt>java.io.OutputStream</tt>, given in the constructor,
+   * <code>java.io.OutputStream</code>, given in the constructor,
    * and encode/decode to/from Base64 notation on the fly.
    *
    * @see Base64
@@ -1891,7 +1891,7 @@ public class Base64
     /**
      * Constructs a {@link Base64.OutputStream} in ENCODE mode.
      *
-     * @param out the <tt>java.io.OutputStream</tt> to which data will be written.
+     * @param out the <code>java.io.OutputStream</code> to which data will be written.
      * @since 1.3
      */
     public OutputStream( java.io.OutputStream out ) {
@@ -1911,7 +1911,7 @@ public class Base64
      * <p>
      * Example: <code>new Base64.OutputStream( out, Base64.ENCODE )</code>
      *
-     * @param out the <tt>java.io.OutputStream</tt> to which data will be written.
+     * @param out the <code>java.io.OutputStream</code> to which data will be written.
      * @param options Specified options.
      * @see Base64#ENCODE
      * @see Base64#DECODE

--- a/core/src/main/java/org/apache/calcite/avatica/util/ByteString.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/ByteString.java
@@ -100,7 +100,7 @@ public class ByteString implements Comparable<ByteString>, Serializable {
   /**
    * Returns the given byte array in hexadecimal format.
    *
-   * <p>For example, <tt>toString(new byte[] {0xDE, 0xAD})</tt>
+   * <p>For example, <code>toString(new byte[] {0xDE, 0xAD})</code>
    * returns {@code "DEAD"}.</p>
    *
    * @param bytes Array of bytes
@@ -149,7 +149,7 @@ public class ByteString implements Comparable<ByteString>, Serializable {
   /**
    * Creates a byte string from a hexadecimal or binary string.
    *
-   * <p>For example, <tt>of("DEAD", 16)</tt>
+   * <p>For example, <code>of("DEAD", 16)</code>
    * returns the same as {@code ByteString(new byte[] {0xDE, 0xAD})}.
    *
    * @param string Array of bytes
@@ -269,8 +269,8 @@ public class ByteString implements Comparable<ByteString>, Serializable {
    * Returns the byte at a given position in the byte string.
    *
    * @param i Index
-   * @throws  IndexOutOfBoundsException if the <tt>index</tt> argument is
-   *          negative or not less than <tt>length()</tt>
+   * @throws  IndexOutOfBoundsException if the <code>index</code> argument is
+   *          negative or not less than <code>length()</code>
    * @return Byte at given position
    */
   public byte byteAt(int i) {

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,9 @@ limitations under the License.
     <httpcore.version>4.4.4</httpcore.version>
     <hydromatic-toolbox.version>0.3</hydromatic-toolbox.version>
     <jackson.version>2.9.4</jackson.version>
+    <!-- Default to html4 for JDK 8 but html5 on jdk9+ -->
+    <javadoc-additionalOptions></javadoc-additionalOptions>
+    <javadoc-link>https://docs.oracle.com/javase/8/docs/api/</javadoc-link>
     <jcip-annotations.version>1.0-1</jcip-annotations.version>
     <jcommander.version>1.48</jcommander.version>
     <jetty.version>9.2.19.v20160908</jetty.version>
@@ -460,9 +463,9 @@ limitations under the License.
              under "reporting", and is more lenient. -->
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <additionalparam>-html5</additionalparam>
+          <additionalOptions>${javadoc-additionalOptions}</additionalOptions>
           <links>
-            <link>https://docs.oracle.com/javase/8/docs/api/</link>
+            <link>${javadoc-link}</link>
           </links>
           <show>private</show>
         </configuration>
@@ -755,6 +758,16 @@ limitations under the License.
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>java9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <javadoc-additionalOptions>-html5</javadoc-additionalOptions>
+        <javadoc-link>https://docs.oracle.com/javase/9/docs/api/</javadoc-link>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
* Add JDK9+ profile to enable -html5 for javadoc