### PR TITLE
[CALCITE-2322] Add fetch size support to connection url and JDBC state…

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public abstract class AvaticaStatement
     implements Statement {
+
   /** The default value for {@link Statement#getFetchSize()}. */
   public static final int DEFAULT_FETCH_SIZE = 100;
 
@@ -108,6 +109,7 @@ public abstract class AvaticaStatement
     this.resultSetType = resultSetType;
     this.resultSetConcurrency = resultSetConcurrency;
     this.resultSetHoldability = resultSetHoldability;
+    this.fetchSize = connection.config().fetchSize(); // Default to connection config fetch size.
     this.signature = signature;
     this.closed = false;
     if (h == null) {

--- a/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
+++ b/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
@@ -77,7 +77,10 @@ public enum BuiltInConnectionProperty implements ConnectionProperty {
   TRUSTSTORE_PASSWORD("truststore_password", Type.STRING, null, false),
 
   HOSTNAME_VERIFICATION("hostname_verification", Type.ENUM, HostnameVerification.STRICT,
-      HostnameVerification.class, false);
+      HostnameVerification.class, false),
+
+  /** Fetch size limit, default is 100 rows. */
+  FETCH_SIZE("fetch_size", Type.NUMBER, AvaticaStatement.DEFAULT_FETCH_SIZE, false);
 
   private final String camelName;
   private final Type type;

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
@@ -56,6 +56,8 @@ public interface ConnectionConfig {
   String truststorePassword();
   /** @see BuiltInConnectionProperty#HOSTNAME_VERIFICATION */
   HostnameVerification hostnameVerification();
+  /** @see BuiltInConnectionProperty#FETCH_SIZE */
+  int fetchSize();
 }
 
 // End ConnectionConfig.java

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
@@ -111,6 +111,10 @@ public class ConnectionConfigImpl implements ConnectionConfig {
         .getEnum(HostnameVerification.class);
   }
 
+  public int fetchSize() {
+    return BuiltInConnectionProperty.FETCH_SIZE.wrap(properties).getInt();
+  }
+
   /** Converts a {@link Properties} object containing (name, value)
    * pairs into a map whose keys are
    * {@link org.apache.calcite.avatica.InternalProperty} objects.

--- a/core/src/main/java/org/apache/calcite/avatica/MetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/MetaImpl.java
@@ -1603,7 +1603,7 @@ public abstract class MetaImpl implements Meta {
         }
         try {
           // currentOffset updated after element is read from `rows` iterator
-          frame = fetch(stmt.handle, currentOffset, AvaticaStatement.DEFAULT_FETCH_SIZE);
+          frame = fetch(stmt.handle, currentOffset, stmt.getFetchSize());
         } catch (NoSuchStatementException e) {
           resetStatement();
           // re-fetch the batch where we left off


### PR DESCRIPTION
Adds the support for both a URL connection param fetch_size and the JDBD Statement API setFetchSize.  This can be used to tune performance for queries that return a large number of rows.