### PR TITLE
[CALCITE-2333] Stop releasing zips

### DIFF
--- a/docker/src/assembly/docker-files.xml
+++ b/docker/src/assembly/docker-files.xml
@@ -21,7 +21,6 @@ limitations under the License.
   <id>docker-files</id>
   <formats>
     <format>tar.gz</format>
-    <format>zip</format>
   </formats>
   <fileSets>
     <fileSet>

--- a/site/_docs/howto.md
+++ b/site/_docs/howto.md
@@ -33,7 +33,7 @@ Here's some miscellaneous documentation about using Avatica.
 Prerequisites are maven (3.2.1 or later)
 and Java (JDK 8 or later) on your path.
 
-Unpack the source distribution `.tar.gz` or `.zip` file,
+Unpack the source distribution `.tar.gz` file,
 `cd` to the root directory of the unpacked source,
 then build using maven:
 
@@ -254,11 +254,8 @@ Check the artifacts:
   * apache-calcite-avatica-X.Y.Z-src.tar.gz
   * apache-calcite-avatica-X.Y.Z-src.tar.gz.asc
   * apache-calcite-avatica-X.Y.Z-src.tar.gz.sha256
-  * apache-calcite-avatica-X.Y.Z-src.zip
-  * apache-calcite-avatica-X.Y.Z-src.zip.asc
-  * apache-calcite-avatica-X.Y.Z-src.zip.sha256
 * Note that the file names start `apache-calcite-avatica-`.
-* In the two source distros `.tar.gz` and `.zip` (currently there is
+* In the source distro `.tar.gz` (currently there is
   no binary distro), check that all files belong to a directory called
   `apache-calcite-avatica-X.Y.Z-src`.
 * That directory must contain files `NOTICE`, `LICENSE`,
@@ -356,7 +353,7 @@ curl -O https://dist.apache.org/repos/dist/release/calcite/KEYS
 # (Assumes your O/S has a 'shasum' command.)
 function checkHash() {
   cd "$1"
-  for i in *.{zip,pom,gz}; do
+  for i in *.{pom,gz}; do
     if [ ! -f $i ]; then
       continue
     fi
@@ -401,7 +398,6 @@ https://dist.apache.org/repos/dist/dev/calcite/apache-calcite-avatica-X.Y.Z-rcN/
 
 The hashes of the artifacts are as follows:
 src.tar.gz.sha256 XXXX
-src.zip.sha256 XXXX
 
 A staged Maven repository is available for review at:
 https://repository.apache.org/content/repositories/orgapachecalcite-NNNN

--- a/site/_docs/howto.md
+++ b/site/_docs/howto.md
@@ -530,7 +530,7 @@ svn ci
 The old releases will remain available in the
 [release archive](http://archive.apache.org/dist/calcite/).
 
-Publish the [Docker images](docker.md).
+Publish the [Docker images](docker.html).
 
 Add a release note by copying
 [site/_posts/2016-11-01-release-1.9.0.md]({{ site.sourceRoot }}/site/_posts/2016-11-01-release-1.9.0.md),

--- a/site/downloads/avatica-go.md
+++ b/site/downloads/avatica-go.md
@@ -48,6 +48,7 @@ Release          | Date       | Commit   | Download
 {% endcomment %}{% capture d1 %}{{ post.date | date: "%F"}}{% endcapture %}{% comment %}
 {% endcomment %}{% capture d2 %}2017-05-01{% endcapture %}{% comment %}
 {% endcomment %}{% capture d3 %}2018-03-01{% endcapture %}{% comment %}
+{% endcomment %}{% capture d4 %}2018-06-01{% endcapture %}{% comment %}
 {% endcomment %}{% if d1 > d3 %}{% comment %}
 {% endcomment %}{% assign digest = "sha256" %}{% comment %}
 {% endcomment %}{% elsif d1 > d2 %}{% comment %}
@@ -61,10 +62,12 @@ Release          | Date       | Commit   | Download
 {% endcomment %} | <a href="{{ p }}/{{ v }}-src.tar.gz{{ q }}">tar</a>{% comment %}
 {% endcomment %} (<a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.tar.gz.{{ digest }}">{{ digest }}</a>{% comment %}
 {% endcomment %} <a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.tar.gz.asc">pgp</a>){% comment %}
+{% endcomment %}{% if d1 < d4 %}{% comment %}
 {% endcomment %} {% raw %}<br>{% endraw %}{% comment %}
 {% endcomment %} <a href="{{ p }}/{{ v }}-src.zip{{ q }}">zip</a>{% comment %}
 {% endcomment %} (<a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.zip.{{ digest }}">{{ digest }}</a>{% comment %}
 {% endcomment %} <a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.zip.asc">pgp</a>){% comment %}
+{% endcomment %}{% endif %}{% comment %}
 {% endcomment %}
 {% endfor %}
 

--- a/site/downloads/avatica.md
+++ b/site/downloads/avatica.md
@@ -50,6 +50,7 @@ Release          | Date       | Commit   | Download
 {% endcomment %}{% capture d1 %}{{ post.date | date: "%F"}}{% endcapture %}{% comment %}
 {% endcomment %}{% capture d2 %}2017-05-01{% endcapture %}{% comment %}
 {% endcomment %}{% capture d3 %}2018-03-01{% endcapture %}{% comment %}
+{% endcomment %}{% capture d4 %}2018-06-01{% endcapture %}{% comment %}
 {% endcomment %}{% if d1 > d3 %}{% comment %}
 {% endcomment %}{% assign digest = "sha256" %}{% comment %}
 {% endcomment %}{% elsif d1 > d2 %}{% comment %}
@@ -63,10 +64,12 @@ Release          | Date       | Commit   | Download
 {% endcomment %} | <a href="{{ p }}/{{ v }}-src.tar.gz{{ q }}">tar</a>{% comment %}
 {% endcomment %} (<a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.tar.gz.{{ digest }}">{{ digest }}</a>{% comment %}
 {% endcomment %} <a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.tar.gz.asc">pgp</a>){% comment %}
+{% endcomment %}{% if d1 < d4 %}{% comment %}
 {% endcomment %} {% raw %}<br>{% endraw %}{% comment %}
 {% endcomment %} <a href="{{ p }}/{{ v }}-src.zip{{ q }}">zip</a>{% comment %}
 {% endcomment %} (<a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.zip.{{ digest }}">{{ digest }}</a>{% comment %}
 {% endcomment %} <a href="{{ d }}/calcite/{{ v }}/{{ v }}-src.zip.asc">pgp</a>){% comment %}
+{% endcomment %}{% endif %}{% comment %}
 {% endcomment %}
 {% endfor %}
 

--- a/src/main/config/assemblies/source-assembly.xml
+++ b/src/main/config/assemblies/source-assembly.xml
@@ -18,7 +18,6 @@ limitations under the License.
 <assembly>
   <id>source-release</id>
   <formats>
-    <format>zip</format>
     <format>tar.gz</format>
   </formats>
   <fileSets>


### PR DESCRIPTION
This updates the website and maven configs to stop releasing zips for future releases.

The site was tested locally and works fine.

Can someone verify that I have updated the pom.xml files correctly?