### PR TITLE
[CALCITE-2341] Fix javadoc plugin incompatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@ limitations under the License.
     <maven-checkstyle-plugin.version>2.12.1</maven-checkstyle-plugin.version>
     <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
-    <!-- Apache 19 has 2.10.4, but need 3.0.0 for [MJAVADOC-524]. -->
-    <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
+    <!-- Apache 19 has 2.10.4, but need 3.0.1 for [MJAVADOC-517]. -->
+    <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
     <maven-scm-provider.version>1.9.4</maven-scm-provider.version>
     <maven-shade-plugin.version>3.1.1</maven-shade-plugin.version>
     <!-- Apache 19 has 2.20.1, but need 2.21.0+ for [MPOM-184] -->


### PR DESCRIPTION
Fix the javadoc plugin incompatibility with JDK10 or higher but
updating the plugin version from 3.0.0 to 3.0.1