### PR TITLE
[CALCITE-2386] Naively wire up struct support

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaSite.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaSite.java
@@ -298,8 +298,9 @@ public class AvaticaSite {
     case Types.NCLOB:
     case Types.REF:
     case Types.SQLXML:
-    case Types.STRUCT:
       throw notImplemented();
+    case Types.STRUCT:
+      return accessor.getStruct();
     case Types.ARRAY:
       return accessor.getArray();
     case Types.BIGINT:

--- a/core/src/main/java/org/apache/calcite/avatica/util/ArrayImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/ArrayImpl.java
@@ -26,6 +26,7 @@ import java.sql.Types;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /** Implementation of JDBC {@link Array}. */
 public class ArrayImpl implements Array {
@@ -224,7 +225,7 @@ public class ArrayImpl implements Array {
     ResultSet leftResultSet = left.getResultSet();
     ResultSet rightResultSet = right.getResultSet();
     while (leftResultSet.next() && rightResultSet.next()) {
-      if (!leftResultSet.getObject(1).equals(rightResultSet.getObject(1))) {
+      if (!Objects.equals(leftResultSet.getObject(1), (rightResultSet.getObject(1)))) {
         return false;
       }
     }

--- a/core/src/main/java/org/apache/calcite/avatica/util/ArrayImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/ArrayImpl.java
@@ -220,6 +220,17 @@ public class ArrayImpl implements Array {
     // nothing to do
   }
 
+  public static boolean equalContents(Array left, Array right) throws SQLException {
+    ResultSet leftResultSet = left.getResultSet();
+    ResultSet rightResultSet = right.getResultSet();
+    while (leftResultSet.next() && rightResultSet.next()) {
+      if (!leftResultSet.getObject(1).equals(rightResultSet.getObject(1))) {
+        return false;
+      }
+    }
+    return !leftResultSet.next() && !rightResultSet.next();
+  }
+
   /** Factory that can create a ResultSet or Array based on a stream of values. */
   public interface Factory {
 

--- a/core/src/main/java/org/apache/calcite/avatica/util/ArrayImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/ArrayImpl.java
@@ -225,7 +225,7 @@ public class ArrayImpl implements Array {
     ResultSet leftResultSet = left.getResultSet();
     ResultSet rightResultSet = right.getResultSet();
     while (leftResultSet.next() && rightResultSet.next()) {
-      if (!Objects.equals(leftResultSet.getObject(1), (rightResultSet.getObject(1)))) {
+      if (!Objects.equals(leftResultSet.getObject(1), rightResultSet.getObject(1))) {
         return false;
       }
     }

--- a/core/src/main/java/org/apache/calcite/avatica/util/Cursor.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/Cursor.java
@@ -30,6 +30,7 @@ import java.sql.NClob;
 import java.sql.Ref;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import java.sql.Struct;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
@@ -121,6 +122,8 @@ public interface Cursor extends AutoCloseable {
     Clob getClob() throws SQLException;
 
     Array getArray() throws SQLException;
+
+    Struct getStruct() throws SQLException;
 
     Date getDate(Calendar calendar) throws SQLException;
 


### PR DESCRIPTION
It seems like Avatica already has struct support, but not in the particular code path used by sqlline. I've tried this out for utterly elementary bits, but no more.

```
> select row(1, 2);
+--------+
| EXPR$0 |
+--------+
| {1, 2} |
+--------+
```