### PR TITLE
[CALCITE-2394] Fix TIMESTAMP accessors: test with non-default, non-zero timezone

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
@@ -967,7 +967,7 @@ public abstract class AbstractCursor implements Cursor {
       if (v == null) {
         return null;
       }
-      return longToTimestamp(v.longValue(), calendar);
+      return new Timestamp(v.longValue());
     }
 
     @Override public String getString() throws SQLException {
@@ -1001,7 +1001,7 @@ public abstract class AbstractCursor implements Cursor {
       if (v == null) {
         return null;
       }
-      return longToTimestamp(v.longValue(), calendar);
+      return new Timestamp(v.longValue());
     }
 
     @Override public Date getDate(Calendar calendar) throws SQLException {
@@ -1022,12 +1022,29 @@ public abstract class AbstractCursor implements Cursor {
               DateTimeUtils.MILLIS_PER_DAY));
     }
 
+    @Override public float getFloat() throws SQLException {
+      throw cannotConvert("float");
+    }
+
+    @Override public double getDouble() throws SQLException {
+      throw cannotConvert("double");
+    }
+
+    @Override public BigDecimal getBigDecimal(int scale) throws SQLException {
+      throw cannotConvert("BigDecimal");
+    }
+
     @Override public String getString() throws SQLException {
       final Number v = getNumber();
       if (v == null) {
         return null;
       }
       return timestampAsString(v.longValue(), null);
+    }
+
+    private SQLException cannotConvert(String targetType) throws SQLException {
+      return new SQLDataException("cannot convert to " + targetType + " ("
+              + this + ")");
     }
   }
 
@@ -1120,14 +1137,6 @@ public abstract class AbstractCursor implements Cursor {
 
     @Override public Timestamp getTimestamp(Calendar calendar) throws SQLException {
       Timestamp timestamp  = (Timestamp) getObject();
-      if (timestamp == null) {
-        return null;
-      }
-      if (calendar != null) {
-        long v = timestamp.getTime();
-        v -= calendar.getTimeZone().getOffset(v);
-        timestamp = new Timestamp(v);
-      }
       return timestamp;
     }
 


### PR DESCRIPTION
This removes some millis-since-epoch arithmetic from the accessor for a timestamp. In fact, no arithmetic should be necessary for absolute instant references on the data plane, but only during pretty printing. The issue manifests as timestamp columns always being off for any non-zero timezone locale.