### PR TITLE
[CALCITE-2704] Multilingual decoded problem

### DIFF
--- a/server/src/main/java/org/apache/calcite/avatica/server/AvaticaJsonHandler.java
+++ b/server/src/main/java/org/apache/calcite/avatica/server/AvaticaJsonHandler.java
@@ -111,9 +111,11 @@ public class AvaticaJsonHandler extends AbstractAvaticaHandler {
             // Reset the offset into the buffer after we're done
             buffer.reset();
           }
+        } else {
+          rawRequest =
+                  new String(rawRequest.getBytes("ISO-8859-1"), "UTF-8");
         }
-        final String jsonRequest =
-            new String(rawRequest.getBytes("ISO-8859-1"), "UTF-8");
+        final String jsonRequest = rawRequest;
         LOG.trace("request: {}", jsonRequest);
 
         HandlerResponse<String> jsonResponse;


### PR DESCRIPTION
"rawRequest = avaticautils.readfully (inputStream, buffer)" uses utf-8 encoding
"rawRequest = new String(rawrequest.getbytes (" iso-8859-1 "), "utf-8 ")" is decoded using iso-8859-1
Cause Chinese garble.