### PR TITLE
[CALCITE-2789] Bump version dependencies Jan 2019

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,13 @@ limitations under the License.
     <version.minor>13</version.minor>
 
     <!-- This list is in alphabetical order. -->
+    <apache-rat-plugin.version>0.13</apache-rat-plugin.version>
     <bouncycastle.version>1.60</bouncycastle.version>
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
     <!-- Needed for JDK 10 javadoc for [LANG-1365] -->
-    <commons-lang3.version>3.8</commons-lang3.version>
-    <docker-maven-plugin.version>1.1.1</docker-maven-plugin.version>
-    <dropwizard-metrics.version>4.0.3</dropwizard-metrics.version>
+    <commons-lang3.version>3.8.1</commons-lang3.version>
+    <docker-maven-plugin.version>1.2.0</docker-maven-plugin.version>
+    <dropwizard-metrics.version>4.0.5</dropwizard-metrics.version>
     <forbiddenapis.version>2.6</forbiddenapis.version>
     <!-- We support guava versions as old as 14.0.1 (the version used by Hive)
          but prefer more recent versions. -->
@@ -78,7 +79,7 @@ limitations under the License.
     <httpclient.version>4.5.6</httpclient.version>
     <httpcore.version>4.4.10</httpcore.version>
     <hydromatic-toolbox.version>0.3</hydromatic-toolbox.version>
-    <jackson.version>2.9.6</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <!-- Default to html4 for JDK 8 but html5 on jdk9+ -->
     <javadoc-additionalOptions />
     <javadoc-link>https://docs.oracle.com/javase/8/docs/api/</javadoc-link>
@@ -87,24 +88,24 @@ limitations under the License.
     <jetty.version>9.4.11.v20180605</jetty.version>
     <junit.version>4.12</junit.version>
     <kerby.version>1.1.1</kerby.version>
-    <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
+    <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
     <maven-scm-api.version>1.10.0</maven-scm-api.version>
     <maven-scm-provider.version>1.10.0</maven-scm-provider.version>
     <!-- ASF 21 provides 3.1.1 but need 3.2.0 due to MSHADE-289 -->
-    <maven-shade-plugin.version>3.2.0</maven-shade-plugin.version>
-    <mockito.version>2.22.0</mockito.version>
-    <os-maven-plugin.version>1.6.0</os-maven-plugin.version>
-    <owasp-dependency-check.version>3.3.2</owasp-dependency-check.version>
+    <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
+    <mockito.version>2.23.4</mockito.version>
+    <os-maven-plugin.version>1.6.1</os-maven-plugin.version>
+    <owasp-dependency-check.version>4.0.2</owasp-dependency-check.version>
     <protobuf.version>3.6.1</protobuf.version>
-    <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>
+    <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <scott-data-hsqldb.version>0.1</scott-data-hsqldb.version>
     <servlet.version>4.0.1</servlet.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <spotbugs.version>3.1.8</spotbugs.version>
-    <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
+    <spotbugs.version>3.1.11</spotbugs.version>
+    <spotbugs-maven-plugin.version>3.1.10</spotbugs-maven-plugin.version>
   </properties>
   <issueManagement>
     <system>Jira</system>
@@ -363,7 +364,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
-        <version>0.12</version>
+        <version>${apache-rat-plugin.version}</version>
         <configuration>
           <excludes>
             <!-- Do not exclude site/target; it should not exist


### PR DESCRIPTION
* apache-rat-plugin 0.12 to 0.13
* commons-lang3 3.8 to 3.8.1
* dependency-check-maven 3.3.2 to 4.0.2
* docker-maven-plugin 1.1.1 to 1.2.0
* jackson 2.9.6 to 2.9.8
* maven-assembly-plugin 3.1.0 to 3.1.1
* maven-shade-plugin 3.2.0 to 3.2.1
* metrics-core 4.0.3 to 4.0.5
* mockito-core 2.22.0 to 2.23.4
* os-maven-plugin 1.6.0 to 1.6.1
* protobuf-maven-plugin 0.5.1 to 0.6.1
* spotbugs 3.1.8 to 3.1.11
* spotbugs-maven-plugin 3.1.8 to 3.1.10