### PR TITLE
[CALCITE-2704] Avoid use of ISO-8859-1 to parse request in JsonHandler

### DIFF
--- a/server/src/main/java/org/apache/calcite/avatica/server/AvaticaJsonHandler.java
+++ b/server/src/main/java/org/apache/calcite/avatica/server/AvaticaJsonHandler.java
@@ -106,14 +106,18 @@ public class AvaticaJsonHandler extends AbstractAvaticaHandler {
           // Avoid a new buffer creation for every HTTP request
           final UnsynchronizedBuffer buffer = threadLocalBuffer.get();
           try (ServletInputStream inputStream = request.getInputStream()) {
-            rawRequest = AvaticaUtils.readFully(inputStream, buffer);
+            byte[] bytes = AvaticaUtils.readFullyToBytes(inputStream, buffer);
+            String encoding = request.getCharacterEncoding();
+            if (encoding == null) {
+              encoding = "UTF-8";
+            }
+            rawRequest = new String(bytes, encoding);
           } finally {
             // Reset the offset into the buffer after we're done
             buffer.reset();
           }
         }
-        final String jsonRequest =
-            new String(rawRequest.getBytes("ISO-8859-1"), "UTF-8");
+        final String jsonRequest = rawRequest;
         LOG.trace("request: {}", jsonRequest);
 
         HandlerResponse<String> jsonResponse;


### PR DESCRIPTION
I'm pretty confident that this one fixes https://issues.apache.org/jira/browse/CALCITE-2704, and this change should be way better than #76.

I've no idea how to test the change though, so please don't ask me to add tests. Thank you.