### PR TITLE
[CALCITE-2945] Use Boolean#equals in Boolean object compare

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionPropertiesImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionPropertiesImpl.java
@@ -94,16 +94,16 @@ public class ConnectionPropertiesImpl implements Meta.ConnectionProperties {
     if (this == that) {
       return this;
     }
-    if (that.isAutoCommit() != null && !this.autoCommit.equals(that.isAutoCommit())) {
+    if (that.isAutoCommit() != null && !Objects.equals(this.autoCommit, that.isAutoCommit())) {
       this.autoCommit = that.isAutoCommit();
       this.isDirty = true;
     }
-    if (that.isReadOnly() != null && !this.readOnly.equals(that.isReadOnly())) {
+    if (that.isReadOnly() != null && !Objects.equals(this.readOnly, that.isReadOnly())) {
       this.readOnly = that.isReadOnly();
       this.isDirty = true;
     }
     if (that.getTransactionIsolation() != null
-        && !that.getTransactionIsolation().equals(this.transactionIsolation)) {
+        && !Objects.equals(this.transactionIsolation, that.getTransactionIsolation())) {
       this.transactionIsolation = that.getTransactionIsolation();
       this.isDirty = true;
     }

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionPropertiesImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionPropertiesImpl.java
@@ -94,11 +94,11 @@ public class ConnectionPropertiesImpl implements Meta.ConnectionProperties {
     if (this == that) {
       return this;
     }
-    if (that.isAutoCommit() != null && this.autoCommit != that.isAutoCommit()) {
+    if (that.isAutoCommit() != null && !this.autoCommit.equals(that.isAutoCommit())) {
       this.autoCommit = that.isAutoCommit();
       this.isDirty = true;
     }
-    if (that.isReadOnly() != null && this.readOnly != that.isReadOnly()) {
+    if (that.isReadOnly() != null && !this.readOnly.equals(that.isReadOnly())) {
       this.readOnly = that.isReadOnly();
       this.isDirty = true;
     }

--- a/core/src/test/java/org/apache/calcite/avatica/ConnectionPropertiesImplTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/ConnectionPropertiesImplTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test class for {@link ConnectionPropertiesImpl}.
+ */
+public class ConnectionPropertiesImplTest {
+
+  @Test
+  public void testMerge() {
+    ConnectionPropertiesImpl connectionProperties1 = new ConnectionPropertiesImpl(
+                Boolean.FALSE, Boolean.TRUE,
+                Integer.MAX_VALUE, "catalog", "schema");
+    ConnectionPropertiesImpl connectionProperties2 = new ConnectionPropertiesImpl(
+                Boolean.FALSE, Boolean.TRUE,
+                Integer.MAX_VALUE, "catalog", "schema");
+    Assert.assertEquals(
+            connectionProperties1.isReadOnly().equals(connectionProperties2.isReadOnly()),
+            true);
+
+    ConnectionPropertiesImpl merged = connectionProperties1.merge(connectionProperties2);
+    Assert.assertEquals(merged.isDirty(), false);
+    Assert.assertEquals(connectionProperties1, merged);
+  }
+}
+
+// End ConnectionPropertiesImplTest.java

--- a/core/src/test/java/org/apache/calcite/avatica/ConnectionPropertiesImplTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/ConnectionPropertiesImplTest.java
@@ -16,8 +16,12 @@
  */
 package org.apache.calcite.avatica;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * Test class for {@link ConnectionPropertiesImpl}.
@@ -27,18 +31,36 @@ public class ConnectionPropertiesImplTest {
   @Test
   public void testMerge() {
     ConnectionPropertiesImpl connectionProperties1 = new ConnectionPropertiesImpl(
-                Boolean.FALSE, Boolean.TRUE,
-                Integer.MAX_VALUE, "catalog", "schema");
+        Boolean.FALSE, Boolean.TRUE, Integer.MAX_VALUE, "catalog", "schema");
     ConnectionPropertiesImpl connectionProperties2 = new ConnectionPropertiesImpl(
-                Boolean.FALSE, Boolean.TRUE,
-                Integer.MAX_VALUE, "catalog", "schema");
-    Assert.assertEquals(
-            connectionProperties1.isReadOnly().equals(connectionProperties2.isReadOnly()),
-            true);
-
+        Boolean.FALSE, Boolean.TRUE, Integer.MAX_VALUE, "catalog", "schema");
+    assertThat(
+        Objects.equals(connectionProperties1.isReadOnly(),
+            connectionProperties2.isReadOnly()), is(true));
+    assertThat(
+        Objects.equals(connectionProperties1.isAutoCommit(),
+            connectionProperties2.isAutoCommit()), is(true));
+    assertThat(
+        Objects.equals(connectionProperties1.getTransactionIsolation(),
+            connectionProperties2.getTransactionIsolation()), is(true));
     ConnectionPropertiesImpl merged = connectionProperties1.merge(connectionProperties2);
-    Assert.assertEquals(merged.isDirty(), false);
-    Assert.assertEquals(connectionProperties1, merged);
+    assertThat(merged.isDirty(), is(false));
+    assertThat(Objects.equals(merged, connectionProperties1), is(true));
+
+    ConnectionPropertiesImpl connectionProperties3 = new ConnectionPropertiesImpl(
+        null, null, null, "catalog", "schema");
+    assertThat(
+        Objects.equals(connectionProperties1.isReadOnly(),
+            connectionProperties3.isReadOnly()), is(false));
+    assertThat(
+        Objects.equals(connectionProperties1.isAutoCommit(),
+            connectionProperties3.isAutoCommit()), is(false));
+    assertThat(
+        Objects.equals(connectionProperties1.getTransactionIsolation(),
+            connectionProperties3.getTransactionIsolation()), is(false));
+    ConnectionPropertiesImpl merged1 = connectionProperties3.merge(connectionProperties1);
+    assertThat(merged1.isDirty(), is(true));
+    assertThat(Objects.equals(merged1, connectionProperties1), is(false));
   }
 }
 


### PR DESCRIPTION
Use Boolean#equals method in Boolean object compare in ConnectionPropertiesImpl#merge function.