### PR TITLE
[CALCITE-2950] Avatica DriverVersion.load leaks InputStream

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/DriverVersion.java
+++ b/core/src/main/java/org/apache/calcite/avatica/DriverVersion.java
@@ -96,8 +96,9 @@ public class DriverVersion {
     int minorVersion = 0;
     int databaseMajorVersion = 0;
     int databaseMinorVersion = 0;
+    InputStream inStream = null;
     try {
-      final InputStream inStream =
+      inStream =
           driverClass.getClassLoader().getResourceAsStream(resourceName);
       if (inStream != null) {
         final Properties properties = new Properties();
@@ -138,6 +139,14 @@ public class DriverVersion {
       }
     } catch (IOException e) {
       e.printStackTrace();
+    } finally {
+      if (inStream != null) {
+        try {
+          inStream.close();
+        } catch (IOException ignore) {
+          ignore.printStackTrace();
+        }
+      }
     }
     return new DriverVersion(
         driverName, driverVersion, productName, productVersion,

--- a/core/src/main/java/org/apache/calcite/avatica/DriverVersion.java
+++ b/core/src/main/java/org/apache/calcite/avatica/DriverVersion.java
@@ -96,10 +96,8 @@ public class DriverVersion {
     int minorVersion = 0;
     int databaseMajorVersion = 0;
     int databaseMinorVersion = 0;
-    InputStream inStream = null;
-    try {
-      inStream =
-          driverClass.getClassLoader().getResourceAsStream(resourceName);
+    try (final InputStream inStream =
+          driverClass.getClassLoader().getResourceAsStream(resourceName)) {
       if (inStream != null) {
         final Properties properties = new Properties();
         properties.load(inStream);
@@ -139,14 +137,6 @@ public class DriverVersion {
       }
     } catch (IOException e) {
       e.printStackTrace();
-    } finally {
-      if (inStream != null) {
-        try {
-          inStream.close();
-        } catch (IOException ignore) {
-          ignore.printStackTrace();
-        }
-      }
     }
     return new DriverVersion(
         driverName, driverVersion, productName, productVersion,


### PR DESCRIPTION
This commit fixes the leak problem at https://issues.apache.org/jira/browse/CALCITE-2950. The fix has been verified by using the procedure described in the JIRA issue. No memory leak observed after applying this fix.