### PR TITLE
[CALCITE-3078] Duplicate code lastDay in calcite-avatica and calcite

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/util/DateTimeUtils.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/DateTimeUtils.java
@@ -993,7 +993,7 @@ public class DateTimeUtils {
     return DateTimeUtils.ymdToUnixDate(y0, m0, d0);
   }
 
-  private static int lastDay(int y, int m) {
+  public static int lastDay(int y, int m) {
     switch (m) {
     case 2:
       return y % 4 == 0


### PR DESCRIPTION
Fix [ISSUE #3078](https://issues.apache.org/jira/browse/CALCITE-3078)

The code of lastDay appears in calcite
```java
 private static int lastDay(int y, int m) {
    switch (m) {
    case 2:
      return y % 4 == 0
          && (y % 100 != 0
          || y % 400 == 0)
          ? 29 : 28;
    case 4:
    case 6:
    case 9:
    case 11:
      return 30;
    default:
      return 31;
    }
  }
```
, and appears in calcite-avatica. I think the duplicate code can change the calcite-avatica to public function then be used by calcite.