### PR TITLE
[CALCITE-3163] AbstractCursor#convertValue() now adheres to JDBC specification

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
@@ -1318,8 +1318,9 @@ public abstract class AbstractCursor implements Cursor {
         return componentAccessor.getInt();
       case Types.BIGINT:
         return componentAccessor.getLong();
-      case Types.FLOAT:
+      case Types.REAL:
         return componentAccessor.getFloat();
+      case Types.FLOAT:
       case Types.DOUBLE:
         return componentAccessor.getDouble();
       case Types.ARRAY:


### PR DESCRIPTION
Outlined in JIRA issue [CALCITE-3163]