### PR TITLE
[CALCITE-3162] Fixed issue that arise when reading Arrays from Calcite through JdbcMeta

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/remote/TypedValue.java
+++ b/core/src/main/java/org/apache/calcite/avatica/remote/TypedValue.java
@@ -724,16 +724,15 @@ public class TypedValue {
       return Float.intBitsToFloat((int) protoValue.getNumberValue());
     case INTEGER:
     case PRIMITIVE_INT:
+    case JAVA_SQL_DATE:
+    case JAVA_SQL_TIME:
       return Long.valueOf(protoValue.getNumberValue()).intValue();
     case PRIMITIVE_SHORT:
     case SHORT:
       return Long.valueOf(protoValue.getNumberValue()).shortValue();
     case LONG:
     case PRIMITIVE_LONG:
-      return Long.valueOf(protoValue.getNumberValue());
-    case JAVA_SQL_DATE:
-    case JAVA_SQL_TIME:
-      return Long.valueOf(protoValue.getNumberValue()).intValue();
+    case NUMBER:
     case JAVA_SQL_TIMESTAMP:
     case JAVA_UTIL_DATE:
       return protoValue.getNumberValue();
@@ -747,8 +746,6 @@ public class TypedValue {
         return new BigDecimal(bigInt, (int) protoValue.getNumberValue());
       }
       return new BigDecimal(protoValue.getStringValueBytes().toStringUtf8());
-    case NUMBER:
-      return Long.valueOf(protoValue.getNumberValue());
     case NULL:
       return null;
     case ARRAY:
@@ -802,7 +799,7 @@ public class TypedValue {
       writeToProtoWithType(builder, o, Common.Rep.DOUBLE);
       return Common.Rep.DOUBLE;
     } else if (o instanceof Float) {
-      writeToProtoWithType(builder, ((Float) o).longValue(), Common.Rep.FLOAT);
+      writeToProtoWithType(builder, o, Common.Rep.FLOAT);
       return Common.Rep.FLOAT;
     } else if (o instanceof BigDecimal) {
       writeToProtoWithType(builder, o, Common.Rep.BIG_DECIMAL);

--- a/server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcResultSet.java
+++ b/server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcResultSet.java
@@ -226,8 +226,8 @@ class JdbcResultSet extends Meta.MetaResultSet {
         // Recursively extracts an Array using its ResultSet-representation
         return extractUsingResultSet(array, calendar);
       } catch (Exception e) {
-        // Not every database might implement Array.getResultSet() using the expected structure. This call
-        // assumes a non-nested array (depends on the db if that's a valid assumption)
+        // Not every database might implement Array.getResultSet() using the expected structure.
+        // This call assumes a non-nested array (depends on the db if that's a valid assumption)
         return extractUsingArray(array, calendar);
       }
     case Types.STRUCT:

--- a/server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcResultSet.java
+++ b/server/src/main/java/org/apache/calcite/avatica/jdbc/JdbcResultSet.java
@@ -32,7 +32,6 @@ import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Struct;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -226,8 +225,8 @@ class JdbcResultSet extends Meta.MetaResultSet {
       try {
         // Recursively extracts an Array using its ResultSet-representation
         return extractUsingResultSet(array, calendar);
-      } catch (UnsupportedOperationException | SQLFeatureNotSupportedException e) {
-        // Not every database might implement Array.getResultSet(). This call
+      } catch (Exception e) {
+        // Not every database might implement Array.getResultSet() using the expected structure. This call
         // assumes a non-nested array (depends on the db if that's a valid assumption)
         return extractUsingArray(array, calendar);
       }


### PR DESCRIPTION
…by handling all exceptions thrown by JdbcResultSet#extractUsingResultSet()

Also fixed a type-conversion issue for Floats in TypedValue#getSerialFromProto() (line 802)

See JIRA issue CALCITE-3162 for more details.