### PR TITLE
CALCITE-3179: Bump Jackson from 2.9.8 to 2.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@ limitations under the License.
     <httpclient.version>4.5.6</httpclient.version>
     <httpcore.version>4.4.10</httpcore.version>
     <hydromatic-toolbox.version>0.3</hydromatic-toolbox.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.9.9</jackson.version>
     <!-- Default to html4 for JDK 8 but html5 on jdk9+ -->
     <javadoc-additionalOptions />
     <javadoc-link>https://docs.oracle.com/javase/8/docs/api/</javadoc-link>


### PR DESCRIPTION
To harmonize the versions of Jackson among the different projects.

