### PR TITLE
[CALCITE-3333] Add pluggable frame size limits

### DIFF
--- a/server/src/main/java/org/apache/calcite/avatica/jdbc/FrameLimiter.java
+++ b/server/src/main/java/org/apache/calcite/avatica/jdbc/FrameLimiter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.jdbc;
+
+import java.sql.ResultSet;
+import java.util.Optional;
+
+/**
+ * Limits the size of single {@link JdbcMeta.Frame} during its construction.
+ */
+interface FrameLimiter {
+
+  /**
+   * Create a new {@link Context} to start limiting the size of a single {@link JdbcMeta.Frame}
+   *
+   * @param resultSet the {@link ResultSet} being used to construct the frame
+   * @return the context, configured according to the specification of this FrameLimiter instance
+   */
+  Context start(ResultSet resultSet);
+
+  /**
+   * Return the optional row count limit for this FrameLimiter.
+   */
+  default Optional<Integer> getRowCountLimit() {
+    return Optional.empty();
+  }
+
+  /**
+   * A context configured by its creating {@link FrameLimiter}, limits a frame within a
+   * single fetch operation.
+   */
+  interface Context {
+
+    /**
+     * Determine if the limit configured in the FrameLimiter has been reached in the
+     * current Frame creation operation.
+     *
+     * @return true if the limit has been reached, otherwise false
+     */
+    boolean limitReached();
+
+    /**
+     * Add a single row that will be included in the Frame
+     *
+     * @param row the row being added
+     */
+    void addRow(Object[] row);
+  }
+}
+// End FrameLimiter.java

--- a/server/src/main/java/org/apache/calcite/avatica/jdbc/FrameLimiters.java
+++ b/server/src/main/java/org/apache/calcite/avatica/jdbc/FrameLimiters.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.jdbc;
+
+import org.apache.calcite.avatica.AvaticaUtils;
+
+import java.sql.ResultSet;
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Collection of factory methods for creation of {@link FrameLimiter} instances.
+ */
+class FrameLimiters {
+
+  private FrameLimiters() {}
+
+  /**
+   * Returns an unlimited {@link FrameLimiter}, which will always provide the
+   * full contents of a ResultSet
+   */
+  static FrameLimiter unlimited() {
+    return resultSet -> new FrameLimiter.Context() {
+      @Override public boolean limitReached() {
+        return false;
+      }
+
+      @Override public void addRow(Object[] row) {
+        AvaticaUtils.discard(row);
+      }
+    };
+  }
+
+  /**
+   * Returns a FrameLimiter which limits the frame size to a given number of rows.
+   *
+   * @param maxRowCount maximum number of rows to be included in the frame
+   */
+  static FrameLimiter rowCountLimited(int maxRowCount) {
+    return new FrameLimiter() {
+
+      @Override public Optional<Integer> getRowCountLimit() {
+        return Optional.of(maxRowCount);
+      }
+
+      @Override public Context start(ResultSet resultSet) {
+        return new FrameLimiter.Context() {
+
+          int rowCount = 0;
+
+          @Override public boolean limitReached() {
+            return rowCount >= maxRowCount;
+          }
+
+          @Override public void addRow(Object[] row) {
+            rowCount++;
+          }
+        };
+      }
+    };
+  }
+
+  /**
+   * Returns a FrameLimiter which will stop frame creation after a given amount of time.
+   *
+   * @param maxFrameMillis maximum number of milliseconds to be used while constructing the frame
+   */
+  static FrameLimiter timeLimited(long maxFrameMillis) {
+    return timeLimited(maxFrameMillis, Clock.systemUTC());
+  }
+
+  /**
+   * Same as {@link #timeLimited(long)}, but allows specifying a custom Clock (for testing)
+   *
+   * @param maxFrameMillis maximum number of milliseconds to be used while constructing the frame
+   * @param clock clock to be used for measuring frame construction duration
+   */
+  static FrameLimiter timeLimited(long maxFrameMillis, Clock clock) {
+    return resultSet -> new FrameLimiter.Context() {
+
+      long timeLimitMillis = clock.millis() + maxFrameMillis;
+
+      @Override public boolean limitReached() {
+        return clock.millis() > timeLimitMillis;
+      }
+
+      @Override public void addRow(Object[] row) {
+        AvaticaUtils.discard(row);
+      }
+    };
+  }
+
+  /**
+   * Returns a FrameLimiter that is the combination of a sequency of underlying FrameLimiters.
+   *
+   * The returned FrameLimiter will return <tt>true</tt> for
+   * {@link FrameLimiter.Context#limitReached()} once any one of the underlying FrameLimiters limits
+   * have been reached.
+   *
+   * @param frameLimiters underlying limiters upon which the combined limiter is to be created.
+   */
+  static FrameLimiter combined(FrameLimiter...frameLimiters) {
+    if (frameLimiters.length == 0) {
+      throw new IllegalArgumentException("No frame limiters supplied");
+    } else if (frameLimiters.length == 1) {
+      return frameLimiters[0];
+    } else {
+      List<FrameLimiter> frameLimiterList = Arrays.asList(frameLimiters);
+      return new FrameLimiter() {
+        @Override public Optional<Integer> getRowCountLimit() {
+          return frameLimiterList.stream()
+              .filter(limiter -> limiter.getRowCountLimit().isPresent())
+              .findFirst().flatMap(FrameLimiter::getRowCountLimit);
+        }
+
+        @Override public Context start(ResultSet resultSet) {
+
+          List<Context> contexts = frameLimiterList.stream()
+              .map(frameLimiter -> frameLimiter.start(resultSet))
+              .collect(Collectors.toList());
+
+          return new Context() {
+            @Override public boolean limitReached() {
+              return contexts.stream().anyMatch(Context::limitReached);
+            }
+
+            @Override public void addRow(Object[] row) {
+              contexts.forEach(c -> c.addRow(row));
+            }
+          };
+        }
+      };
+    }
+  }
+}
+// End FrameLimiters.java

--- a/server/src/test/java/org/apache/calcite/avatica/jdbc/FrameLimitersTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/jdbc/FrameLimitersTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.jdbc;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.ResultSet;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link FrameLimiters}
+ */
+public class FrameLimitersTest {
+
+  private static final ResultSet RESULT_SET = Mockito.mock(ResultSet.class);
+  private static final Object[] ROW = {1L, "ONE"};
+
+  @Test public void testUnlimited() {
+    FrameLimiter unlimited = FrameLimiters.unlimited();
+    assertEquals(Optional.empty(), unlimited.getRowCountLimit());
+    FrameLimiter.Context limiterContext = unlimited.start(RESULT_SET);
+    assertFalse(limiterContext.limitReached());
+    limiterContext.addRow(ROW);
+    assertFalse(limiterContext.limitReached());
+  }
+
+  @Test public void testRowCountLimited() {
+    FrameLimiter rowCountLimited = FrameLimiters.rowCountLimited(2);
+    assertEquals(Optional.of(2), rowCountLimited.getRowCountLimit());
+    FrameLimiter.Context limiterContext = rowCountLimited.start(RESULT_SET);
+    assertFalse(limiterContext.limitReached());
+    limiterContext.addRow(ROW);
+    assertFalse(limiterContext.limitReached());
+    limiterContext.addRow(ROW);
+    assertTrue(limiterContext.limitReached());
+  }
+
+  @Test public void testTimelimited() {
+    TestClock testClock = new TestClock();
+    FrameLimiter timeLimited = FrameLimiters.timeLimited(2, testClock);
+    assertEquals(Optional.empty(), timeLimited.getRowCountLimit());
+    FrameLimiter.Context limiterContext = timeLimited.start(RESULT_SET);
+
+    assertFalse(limiterContext.limitReached());
+    limiterContext.addRow(ROW);
+    testClock.addMillis(2);
+    assertFalse(limiterContext.limitReached());
+    limiterContext.addRow(ROW);
+    testClock.addMillis(1);
+    assertTrue(limiterContext.limitReached());
+  }
+
+  @Test
+  public void testCombined() {
+    TestClock testClock = new TestClock();
+    FrameLimiter timeLimited = FrameLimiters.timeLimited(2, testClock);
+    FrameLimiter rowCountLimited = FrameLimiters.rowCountLimited(3);
+
+    FrameLimiter combined = FrameLimiters.combined(timeLimited, rowCountLimited);
+    assertEquals(Optional.of(3), combined.getRowCountLimit());
+
+    // Test that the clock-based limiting works
+    FrameLimiter.Context limiterContext = combined.start(RESULT_SET);
+    assertFalse(limiterContext.limitReached());
+    limiterContext.addRow(ROW);
+    testClock.addMillis(2);
+    assertFalse(limiterContext.limitReached());
+    limiterContext.addRow(ROW);
+    testClock.addMillis(1);
+    assertTrue(limiterContext.limitReached());
+
+    // Test that count-based limiting works
+    limiterContext = rowCountLimited.start(RESULT_SET);
+    assertFalse(limiterContext.limitReached());
+    limiterContext.addRow(ROW);
+    assertFalse(limiterContext.limitReached());
+    limiterContext.addRow(ROW);
+    assertFalse(limiterContext.limitReached());
+    limiterContext.addRow(ROW);
+    assertTrue(limiterContext.limitReached());
+  }
+
+  /**
+   * Clock implementation that allows specifying the current time
+   */
+  private static class TestClock extends Clock {
+
+    private Instant currentTime = Instant.now();
+
+    @Override public ZoneId getZone() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public Clock withZone(ZoneId zone) {
+      throw new UnsupportedOperationException();
+    }
+
+    void addMillis(long millis) {
+      this.currentTime = currentTime.plusMillis(millis);
+    }
+
+    @Override public Instant instant() {
+      return this.currentTime;
+    }
+  }
+}
+// End FrameLimitersTest.java


### PR DESCRIPTION
Add an ability to plug in custom limiting of ResultSet frame
sizes by overriding a method of JdbcMeta.

The intention is to allow limiting the size of a ResultSet
frame based on the amount of time taken to create it, in addition
to limiting based on the number of rows in the frame.