### PR TITLE
[CALCITE-2704] Avoid use of ISO-8859-1 to parse request in JsonHandler

### DIFF
--- a/server/src/main/java/org/apache/calcite/avatica/server/AvaticaJsonHandler.java
+++ b/server/src/main/java/org/apache/calcite/avatica/server/AvaticaJsonHandler.java
@@ -105,14 +105,18 @@ public class AvaticaJsonHandler extends AbstractAvaticaHandler {
           // Avoid a new buffer creation for every HTTP request
           final UnsynchronizedBuffer buffer = threadLocalBuffer.get();
           try (ServletInputStream inputStream = request.getInputStream()) {
-            rawRequest = AvaticaUtils.readFully(inputStream, buffer);
+            byte[] bytes = AvaticaUtils.readFullyToBytes(inputStream, buffer);
+            String encoding = request.getCharacterEncoding();
+            if (encoding == null) {
+              encoding = "UTF-8";
+            }
+            rawRequest = new String(bytes, encoding);
           } finally {
             // Reset the offset into the buffer after we're done
             buffer.reset();
           }
         }
-        final String jsonRequest =
-            new String(rawRequest.getBytes("ISO-8859-1"), "UTF-8");
+        final String jsonRequest = rawRequest;
         LOG.trace("request: {}", jsonRequest);
 
         HandlerResponse<String> jsonResponse;

--- a/server/src/test/java/org/apache/calcite/avatica/remote/RemoteMetaTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/remote/RemoteMetaTest.java
@@ -716,6 +716,24 @@ public class RemoteMetaTest {
       assertEquals(props, originalProps);
     }
   }
+
+  @Test public void testUnicodeCharacters() throws Exception {
+    ConnectionSpec.getDatabaseLock().lock();
+    try (AvaticaConnection conn = (AvaticaConnection) DriverManager.getConnection(url)) {
+      final AvaticaStatement statement = conn.createStatement();
+      ResultSet rs = statement.executeQuery(
+          "select * from (values ('您好', 'こんにちは', '안녕하세요'))");
+      assertThat(rs.next(), is(true));
+      assertEquals("您好", rs.getString(1));
+      assertEquals("こんにちは", rs.getString(2));
+      assertEquals("안녕하세요", rs.getString(3));
+      rs.close();
+      statement.close();
+      conn.close();
+    } finally {
+      ConnectionSpec.getDatabaseLock().unlock();
+    }
+  }
 }
 
 // End RemoteMetaTest.java


### PR DESCRIPTION
Credits to the [PR](https://github.com/apache/calcite-avatica/pull/85) from @vlsi.
Add a test for the fix.