### PR TITLE
[CALCITE-4147] Rename "master" branch to "main"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         ./gradlew --no-parallel --no-daemon build javadoc
 
   linux-avatica:
-    name: 'Linux (JDK 8), Avatica master'
+    name: 'Linux (JDK 8), Avatica main'
     runs-on: ubuntu-latest
     steps:
     - name: 'Set up JDK 8'
@@ -56,12 +56,12 @@ jobs:
         fetch-depth: 50
     - name: 'Install Avatica to Maven Local'
       run: |
-        ./gradlew publishToMavenLocal -Pcalcite.avatica.version=1.0.0-dev-master -PskipJavadoc
+        ./gradlew publishToMavenLocal -Pcalcite.avatica.version=1.0.0-dev-main -PskipJavadoc
     - name: 'Test Calcite'
       run: |
         git clone --depth 100 https://github.com/apache/calcite.git ../calcite
         cd ../calcite
-        ./gradlew --no-parallel --no-daemon build -Pcalcite.avatica.version=1.0.0-dev-master-SNAPSHOT -PenableMavenLocal
+        ./gradlew --no-parallel --no-daemon build -Pcalcite.avatica.version=1.0.0-dev-main-SNAPSHOT -PenableMavenLocal
 
   linux:
     name: 'Linux (JDK 17)'

--- a/.github/workflows/publish-non-release-website-updates.yml
+++ b/.github/workflows/publish-non-release-website-updates.yml
@@ -19,7 +19,7 @@ name: Publish non-release website updates
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'site/**'                       # Trigger only for changes to files in the site/ folder
       - '!site/_docs/**'                # except for files in the site/_docs/ folder
@@ -54,5 +54,5 @@ jobs:
           git add .
           if ! git diff-index --quiet HEAD; then
             git commit -m "Website deployed from calcite-avatica@$GITHUB_SHA"
-            git push origin master
+            git push origin main
           fi

--- a/.github/workflows/publish-site-and-javadocs-on-release.yml
+++ b/.github/workflows/publish-site-and-javadocs-on-release.yml
@@ -49,5 +49,5 @@ jobs:
           git add .
           if ! git diff-index --quiet HEAD; then
             git commit -m "Website deployed from calcite-avatica@$GITHUB_SHA"
-            git push origin master
+            git push origin main
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,7 @@ matrix:
 
 branches:
   only:
-    - master
-    - new-master
+    - main
     - javadoc
     - stage
     - /^branch-.*$/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 {% endcomment %}
 -->
-[![Build Status](https://travis-ci.org/apache/calcite-avatica.svg?branch=master)](https://travis-ci.org/apache/calcite-avatica)
+[![Build Status](https://travis-ci.org/apache/calcite-avatica.svg?branch=main)](https://travis-ci.org/apache/calcite-avatica)
 [![CI Status](https://github.com/apache/calcite-avatica/workflows/CI/badge.svg)](https://github.com/apache/calcite-avatica/actions)
 
 # Apache Calcite -- Avatica

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ val enableGradleMetadata by props()
 ide {
     copyrightToAsf()
     ideaInstructionsUri =
-        uri("https://github.com/apache/calcite-avatica/blob/master/CONTRIBUTING.md#intellij")
+        uri("https://github.com/apache/calcite-avatica/blob/main/CONTRIBUTING.md#intellij")
     doNotDetectFrameworks("android", "jruby")
 }
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,9 +33,9 @@ The other Dockerfiles must be built by hand.
 
 A number of Dockerfiles for different databases are provided. Presently, they include:
 
-* [HyperSQL](https://github.com/apache/calcite-avatica/tree/master/docker/src/main/docker/hypersql)
-* [MySQL](https://github.com/apache/calcite-avatica/tree/master/docker/src/main/docker/mysql)
-* [PostgreSQL](https://github.com/apache/calcite-avatica/tree/master/docker/src/main/docker/postgresql)
+* [HyperSQL](https://github.com/apache/calcite-avatica/tree/main/docker/src/main/docker/hypersql)
+* [MySQL](https://github.com/apache/calcite-avatica/tree/main/docker/src/main/docker/mysql)
+* [PostgreSQL](https://github.com/apache/calcite-avatica/tree/main/docker/src/main/docker/postgresql)
 
 ## Docker Hub
 

--- a/site/README.md
+++ b/site/README.md
@@ -26,7 +26,7 @@ a sub-directory of the
 
 You can build the site manually using your environment or use the docker compose file.
 
-The site is automatically built and published following the process outlined in the [Calcite repository](https://github.com/apache/calcite/blob/master/site/README.md).
+The site is automatically built and published following the process outlined in the [Calcite repository](https://github.com/apache/calcite/blob/main/site/README.md).
 
 # Previewing the website locally
 
@@ -35,7 +35,7 @@ The site is automatically built and published following the process outlined in 
 ### Setup your environment
 
 Similar to the instructions to
-[set up the Calcite web site](https://github.com/apache/calcite-avatica/blob/master/site/README.md).
+[set up the Calcite web site](https://github.com/apache/calcite-avatica/blob/main/site/README.md).
 
 Site generation currently works best with ruby-2.7.4.
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -31,7 +31,7 @@ collections:
     output: true
 
 # The URL where the code can be found
-sourceRoot: https://github.com/apache/calcite-avatica/tree/master
+sourceRoot: https://github.com/apache/calcite-avatica/tree/main
 
 # The URL where Avatica Javadocs are located
 apiRoot: /avatica/javadocAggregate

--- a/site/_docs/compatibility.md
+++ b/site/_docs/compatibility.md
@@ -98,8 +98,8 @@ automation around verifying the test cases as a part of the Maven build.
 For more information on running this TCK, including specific instructions for
 running the TCK, reference the provided [README][github-tck-readme] file.
 
-[github-tck]: https://github.com/apache/calcite-avatica/tree/master/tck
-[github-tck-tests]: https://github.com/apache/calcite-avatica/tree/master/tck/src/main/java/org/apache/calcite/avatica/tck/tests
-[github-standalone-server]: https://github.com/apache/calcite-avatica/tree/master/standalone-server
-[github-tck-readme]: https://github.com/apache/calcite-avatica/tree/master/tck/README.md
-[github-tck-yml-file]: https://github.com/apache/calcite-avatica/tree/master/tck/src/main/resources/example_config.yml
+[github-tck]: https://github.com/apache/calcite-avatica/tree/main/tck
+[github-tck-tests]: https://github.com/apache/calcite-avatica/tree/main/tck/src/main/java/org/apache/calcite/avatica/tck/tests
+[github-standalone-server]: https://github.com/apache/calcite-avatica/tree/main/standalone-server
+[github-tck-readme]: https://github.com/apache/calcite-avatica/tree/main/tck/README.md
+[github-tck-yml-file]: https://github.com/apache/calcite-avatica/tree/main/tck/src/main/resources/example_config.yml

--- a/site/_docs/index.md
+++ b/site/_docs/index.md
@@ -25,7 +25,7 @@ limitations under the License.
 Avatica is a framework for building JDBC and ODBC drivers for databases,
 and an RPC wire protocol.
 
-![Avatica Architecture](https://raw.githubusercontent.com/julianhyde/share/master/slides/avatica-architecture.png)
+![Avatica Architecture](https://raw.githubusercontent.com/julianhyde/share/main/slides/avatica-architecture.png)
 
 Avatica's Java binding has very few dependencies.
 Even though it is part of Apache Calcite it does not depend on other parts of

--- a/site/develop/avatica.md
+++ b/site/develop/avatica.md
@@ -78,20 +78,14 @@ the JIRA case number, like this:
 [CALCITE-345] AssertionError in RexToLixTranslator comparing to date literal
 {% endhighlight %}
 
-If your change had multiple commits, use `git rebase -i master` to
+If your change had multiple commits, use `git rebase -i main` to
 squash them into a single commit, and to bring your code up to date
 with the latest on the main line.
 
 Then push your commit(s) to github, and create a pull request from
-your branch to the calcite master branch. Update the JIRA case
+your branch to the calcite main branch. Update the JIRA case
 to reference your pull request, and a committer will review your
 changes.
-
-## Continuous Integration Testing
-
-Calcite has a collection of Jenkins jobs on ASF-hosted infrastructure.
-They are all organized in a single view and available at
-[https://builds.apache.org/view/A-D/view/Calcite/job/Calcite-Avatica-Master/](https://builds.apache.org/view/A-D/view/Calcite/job/Calcite-Avatica-Master/).
 
 ## Getting started
 

--- a/tck/README.md
+++ b/tck/README.md
@@ -75,6 +75,6 @@ while the following tests will be run for cross-version compatibility:
 Any errors encountered will be printed to the terminal. The final output of the script
 will be a summary of both the identity tests and the cross-version tests for easy consumption.
 
-[example-config-yml]: https://github.com/apache/calcite-avatica/tree/master/tck/src/main/resources/example_config.yml
+[example-config-yml]: https://github.com/apache/calcite-avatica/tree/main/tck/src/main/resources/example_config.yml
 [legacy-readme]: https://github.com/joshelser/legacy-avatica-hsqldb-server/blob/master/README.md
-[test-runner-script]: https://github.com/apache/calcite-avatica/tree/master/tck/src/main/ruby/test_runner.rb
+[test-runner-script]: https://github.com/apache/calcite-avatica/tree/main/tck/src/main/ruby/test_runner.rb


### PR DESCRIPTION
This would need to happen in concert with changes to the Calcite repo.
Although I think perhaps the first (and lowest impact) change will be to the site repo.

**Note: This PR is merely to help with review. It should not be merged as it will eventually replace `master`**