### PR TITLE
CALCITE-4196 Consume all data from client before replying with HTTP…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ settings.xml
 /target/
 /*/target/
 /shaded/*/target/
-bin

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ settings.xml
 /target/
 /*/target/
 /shaded/*/target/
+bin

--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaUtils.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaUtils.java
@@ -57,6 +57,8 @@ public class AvaticaUtils {
     }
   };
 
+  private static final int SKIP_BUFFER_SIZE = 4096;
+
   private AvaticaUtils() {}
 
   static {
@@ -284,6 +286,26 @@ public class AvaticaUtils {
       buffer.write(bytes, 0, count);
     }
     return buffer.toArray();
+  }
+
+  /**
+   * Reads and discards all data available on the InputStream.
+   */
+  public static void skipFully(InputStream inputStream) throws IOException {
+    byte[] temp = null;
+    while (true) {
+      long bytesSkipped = inputStream.skip(Long.MAX_VALUE);
+      if (bytesSkipped == 0) {
+        if (temp == null) {
+          temp = new byte[SKIP_BUFFER_SIZE];
+        }
+        int bytesRead = inputStream.read(temp, 0, SKIP_BUFFER_SIZE);
+        if (bytesRead < 0) {
+          // EOF
+          return;
+        }
+      }
+    }
   }
 
   /** Invokes {@code Statement#setLargeMaxRows}, falling back on

--- a/core/src/test/java/org/apache/calcite/avatica/test/AvaticaUtilsTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/test/AvaticaUtilsTest.java
@@ -23,8 +23,12 @@ import org.apache.calcite.avatica.util.ByteString;
 
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -32,9 +36,13 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
 
+import static org.apache.calcite.avatica.AvaticaUtils.skipFully;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -268,6 +276,31 @@ public class AvaticaUtilsTest {
     copyBytes[3] = 11;
     assertThat(s.getBytes()[3], is((byte) 92));
     assertThat(s, is(s2));
+  }
+
+  @Test public void testSkipFully() throws IOException {
+    InputStream in = of("");
+    assertEquals(0, in.available());
+    skipFully(in);
+    assertEquals(0, in.available());
+
+    in = of("asdf");
+    assertEquals(4, in.available());
+    skipFully(in);
+    assertEquals(0, in.available());
+
+    in = of("asdfasdf");
+    for (int i = 0; i < 4; i++) {
+      assertNotEquals(-1, in.read());
+    }
+    assertEquals(4, in.available());
+    skipFully(in);
+    assertEquals(0, in.available());
+  }
+
+  /** Returns an InputStream of UTF-8 encoded bytes from the provided string */
+  InputStream of(String str) {
+    return new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
   }
 
   /** Dummy implementation of {@link ConnectionProperty}. */

--- a/server/src/main/java/org/apache/calcite/avatica/server/AbstractAvaticaHandler.java
+++ b/server/src/main/java/org/apache/calcite/avatica/server/AbstractAvaticaHandler.java
@@ -23,8 +23,6 @@ import org.apache.calcite.avatica.remote.Service.ErrorResponse;
 
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -38,7 +36,6 @@ import javax.servlet.http.HttpServletResponse;
  */
 public abstract class AbstractAvaticaHandler extends AbstractHandler
     implements MetricsAwareAvaticaHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(AbstractAvaticaHandler.class);
 
   private static final ErrorResponse UNAUTHORIZED_ERROR = new ErrorResponse(
       Collections.<String>emptyList(), "User is not authenticated",

--- a/server/src/test/java/org/apache/calcite/avatica/AvaticaSpnegoTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/AvaticaSpnegoTest.java
@@ -251,7 +251,6 @@ public class AvaticaSpnegoTest extends HttpBaseTest {
       assertEquals(3, results.getInt(1));
     }
   }
-
 }
 
 // End AvaticaSpnegoTest.java

--- a/server/src/test/java/org/apache/calcite/avatica/server/AbstractAvaticaHandlerTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/server/AbstractAvaticaHandlerTest.java
@@ -26,12 +26,15 @@ import org.junit.Test;
 
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
+import javax.servlet.ServletInputStream;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,9 +62,13 @@ public class AbstractAvaticaHandlerTest {
 
   @Test public void disallowUnauthenticatedUsers() throws Exception {
     ServletOutputStream os = mock(ServletOutputStream.class);
+    ServletInputStream is = mock(ServletInputStream.class);
+
+    when(is.read(any(byte[].class), anyInt(), anyInt())).thenReturn(-1);
 
     when(config.getAuthenticationType()).thenReturn(AuthenticationType.SPNEGO);
     when(request.getRemoteUser()).thenReturn(null);
+    when(request.getInputStream()).thenReturn(is);
     when(response.getOutputStream()).thenReturn(os);
 
     assertFalse(handler.isUserPermitted(config, baseRequest, request, response));


### PR DESCRIPTION
…/401

SPNEGO's handshake involves sending an HTTP/401 to "challenge" the
client to reply with authentication data. If the client is sending
a significant amount of data in the original request, the client
will still be writing this data when the server replies. This causes
the client to receive a TCP Reset when it continues to write data, and
ultimately manifests in a "Broken Pipe" runtime exception.

The fix is to simply consume all data the client wrote prior to
responding with the HTTP/401.

This also changed some stuff in AvaticaProtobufHandler to reduce a level of nested conditionals and fix a Logger class. The overall flow/purpose of that class did not change.