### PR TITLE
Bump Gradle 6.7 -> 6.8.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -266,6 +266,11 @@ allprojects {
             sourceCompatibility = JavaVersion.VERSION_1_8
             targetCompatibility = JavaVersion.VERSION_1_8
         }
+        configure<JavaPluginExtension> {
+            consistentResolution {
+                useCompileClasspathVersions()
+            }
+        }
 
         repositories {
             if (enableMavenLocal) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,7 +16,7 @@
 #
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=8ad57759019a9233dc7dc4d1a530cefe109dc122000d57f7e623f8cf4ba9dfc4
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionSha256Sum=fd591a34af7385730970399f473afabdb8b28d57fd97d6625c388d090039d6fd
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
See https://docs.gradle.org/6.8.1/release-notes.html

- Faster Kotlin DSL script compilation
- Vendor selection for Java toolchains
- Task execution in composite builds
- Consistent dependency resolution