### PR TITLE
[CALCITE-4476] DateTimeUtils.timeStringToUnixDate may produce wrong time (Vladimir Ozerov)

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/util/DateTimeUtils.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/DateTimeUtils.java
@@ -666,15 +666,15 @@ public class DateTimeUtils {
     int milli;
     if (colon1 < 0) {
       hour = Integer.parseInt(v.trim());
-      minute = 1;
-      second = 1;
+      minute = 0;
+      second = 0;
       milli = 0;
     } else {
       hour = Integer.parseInt(v.substring(start, colon1).trim());
       final int colon2 = v.indexOf(':', colon1 + 1);
       if (colon2 < 0) {
         minute = Integer.parseInt(v.substring(colon1 + 1).trim());
-        second = 1;
+        second = 0;
         milli = 0;
       } else {
         minute = Integer.parseInt(v.substring(colon1 + 1, colon2).trim());

--- a/core/src/test/java/org/apache/calcite/avatica/util/DateTimeUtilsTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/DateTimeUtilsTest.java
@@ -225,6 +225,8 @@ public class DateTimeUtilsTest {
   }
 
   @Test public void testTimeToString() {
+    checkTimeString("00", "00:00:00", 0, 0);
+    checkTimeString("00:00", "00:00:00", 0, 0);
     checkTimeString("00:00:00", 0, 0);
     checkTimeString("23:59:59", 0, 86400000 - 1000);
     checkTimeString("23:59:59.1", 1, 86400000 - 1000 + 100);
@@ -270,13 +272,17 @@ public class DateTimeUtilsTest {
   }
 
   private void checkTimeString(String s, int p, int d) {
-    int digitsAfterPoint = s.indexOf('.') >= 0
-        ? s.length() - s.indexOf('.') - 1
+    checkTimeString(s, s, p, d);
+  }
+
+  private void checkTimeString(String string, String expectedString, int p, int d) {
+    int digitsAfterPoint = string.indexOf('.') >= 0
+        ? string.length() - string.indexOf('.') - 1
         : 0;
     if (digitsAfterPoint == p) {
-      assertThat(unixTimeToString(d, p), is(s));
+      assertThat(unixTimeToString(d, p), is(expectedString));
     }
-    assertThat(timeStringToUnixDate(s), is(d));
+    assertThat(timeStringToUnixDate(string), is(d));
   }
 
   @Test public void testTimestampToString() {


### PR DESCRIPTION
Fixes [#4476](https://issues.apache.org/jira/browse/CALCITE-4476)