### PR TITLE
[CALCITE-2489] Order of fields in JavaTypeFactoryImpl#createStructTyp…

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/Meta.java
+++ b/core/src/main/java/org/apache/calcite/avatica/Meta.java
@@ -672,6 +672,16 @@ public interface Meta {
       return new CursorFactory(Style.MAP, null, null, fieldNames);
     }
 
+    /**
+     * Deduces the appropriate {@code CursorFactory} for accessing the underlying
+     * result set. For result sets composed by records, {@code resultClazz} must
+     * be not null, and each field name in {@code columns} must match one of its
+     * public fields.
+     * @param columns The columns metadata for the result set
+     * @param resultClazz The class representing the records, if any
+     * @return the appropriate {@code CursorFactory} for the underlying result set
+     * @throws RuntimeException if the field name validation fails
+     */
     public static CursorFactory deduce(List<ColumnMetaData> columns,
         Class resultClazz) {
       if (columns.size() == 1) {

--- a/core/src/main/java/org/apache/calcite/avatica/MetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/MetaImpl.java
@@ -89,14 +89,9 @@ public abstract class MetaImpl implements Meta {
           (Iterable<Object[]>) (Iterable) iterable;
       return new ArrayIteratorCursor(iterable1.iterator());
     case RECORD:
-      @SuppressWarnings("unchecked") final Class<Object> clazz =
-          cursorFactory.clazz;
-      return new RecordIteratorCursor<Object>(iterable.iterator(), clazz);
     case RECORD_PROJECTION:
-      @SuppressWarnings("unchecked") final Class<Object> clazz2 =
-          cursorFactory.clazz;
-      return new RecordIteratorCursor<Object>(iterable.iterator(), clazz2,
-          cursorFactory.fields);
+      @SuppressWarnings("unchecked") final Class<Object> clazz = cursorFactory.clazz;
+      return new RecordIteratorCursor<>(iterable.iterator(), clazz, cursorFactory.fields);
     case LIST:
       @SuppressWarnings("unchecked") final Iterable<List<Object>> iterable2 =
           (Iterable<List<Object>>) (Iterable) iterable;
@@ -139,15 +134,8 @@ public abstract class MetaImpl implements Meta {
       return list;
     case RECORD:
     case RECORD_PROJECTION:
-      final Field[] fields;
-      switch (cursorFactory.style) {
-      case RECORD:
-        fields = cursorFactory.clazz.getFields();
-        break;
-      default:
-        fields = cursorFactory.fields.toArray(
-            new Field[cursorFactory.fields.size()]);
-      }
+      final Field[] fields = cursorFactory.fields.toArray(
+          new Field[cursorFactory.fields.size()]);
       for (Object o : iterable) {
         final Object[] objects = new Object[fields.length];
         for (int i = 0; i < fields.length; i++) {

--- a/core/src/main/java/org/apache/calcite/avatica/util/RecordIteratorCursor.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/RecordIteratorCursor.java
@@ -37,7 +37,9 @@ public class RecordIteratorCursor<E> extends IteratorCursor<E> {
    *
    * @param iterator Iterator
    * @param clazz Element type
+   * @deprecated Use {@link #RecordIteratorCursor(Iterator, Class, List)}
    */
+  @Deprecated // to be removed before 2.0
   public RecordIteratorCursor(Iterator<E> iterator, Class<E> clazz) {
     this(iterator, clazz, Arrays.asList(clazz.getFields()));
   }

--- a/core/src/test/java/org/apache/calcite/avatica/CursorFactoryDeduceTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/CursorFactoryDeduceTest.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica;
+
+import org.apache.calcite.avatica.util.Cursor;
+import org.apache.calcite.avatica.util.Unsafe;
+
+import org.junit.Test;
+
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@code Meta.CursorFactory} relative to deducing a cursor factory
+ * from the columns metadata.
+ */
+public class CursorFactoryDeduceTest {
+
+  static final ColumnMetaData.AvaticaType INT_TYPE =
+      ColumnMetaData.scalar(Types.INTEGER, "INT", ColumnMetaData.Rep.PRIMITIVE_INT);
+  static final ColumnMetaData.AvaticaType STRING_TYPE =
+      ColumnMetaData.scalar(Types.VARCHAR, "STRING", ColumnMetaData.Rep.STRING);
+  static final ColumnMetaData.AvaticaType DOUBLE_TYPE =
+      ColumnMetaData.scalar(Types.DOUBLE, "DOUBLE", ColumnMetaData.Rep.DOUBLE);
+
+  static final List<Object> ROWS = IntStream.range(1, 5)
+      .mapToObj(i -> (Object) new SimplePOJO(i, Integer.toString(i), (double) i))
+      .collect(Collectors.toList());
+
+  /**
+   * Simple POJO for testing cursors over Java objects.
+   */
+  protected static class SimplePOJO {
+    public int intField;
+    public String stringField;
+    public Double doubleField;
+
+    SimplePOJO(int intField, String stringField, Double doubleField) {
+      this.intField = intField;
+      this.stringField = stringField;
+      this.doubleField = doubleField;
+    }
+
+    @Override public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+
+      if (o == null) {
+        return false;
+      }
+
+      if (getClass() != o.getClass()) {
+        return false;
+      }
+
+      SimplePOJO pjo = (SimplePOJO) o;
+
+      return Objects.equals(stringField, pjo.stringField)
+          && Objects.equals(intField, pjo.intField)
+          && Objects.equals(doubleField, pjo.doubleField);
+    }
+
+    @Override public int hashCode() {
+      return Objects.hash(stringField, intField, doubleField);
+    }
+  }
+
+  /**
+   * Deducing the cursor from a single column having a Java object as type.
+   */
+  @Test public void deduceObjectCursorFactory() throws Exception {
+    ColumnMetaData.Rep rep = ColumnMetaData.Rep.of(SimplePOJO.class);
+    ColumnMetaData.AvaticaType pojoType =
+        ColumnMetaData.scalar(Types.OTHER, "OTHER", rep);
+
+    ColumnMetaData pojoMetadata =
+        MetaImpl.columnMetaData("POJO", 1, pojoType, true);
+
+    List<ColumnMetaData> columnMetaDataList = Collections.singletonList(pojoMetadata);
+
+    Meta.CursorFactory cursorFactory =
+        Meta.CursorFactory.deduce(columnMetaDataList, SimplePOJO.class);
+
+    try (Cursor cursor = MetaImpl.createCursor(cursorFactory, ROWS)) {
+      List<Cursor.Accessor> accessors =
+          cursor.createAccessors(columnMetaDataList, Unsafe.localCalendar(), null);
+
+      assertEquals(1, accessors.size());
+      Cursor.Accessor accessor = accessors.get(0);
+
+      for (Object row : ROWS) {
+        assertTrue(cursor.next());
+        assertEquals(row, accessor.getObject());
+      }
+
+      assertFalse(cursor.next());
+    }
+  }
+
+  /**
+   * Deducing the cursor when columns are the fields of a Java object.
+   */
+  @Test public void deduceRecordCursorFactory() throws Exception {
+    List<ColumnMetaData> columnsMetaDataList = Arrays.asList(
+        MetaImpl.columnMetaData("intField", 1, INT_TYPE, true),
+        MetaImpl.columnMetaData("stringField", 2, STRING_TYPE, true),
+        MetaImpl.columnMetaData("doubleField", 3, DOUBLE_TYPE, true));
+
+    Meta.CursorFactory cursorFactory =
+        Meta.CursorFactory.deduce(columnsMetaDataList, SimplePOJO.class);
+
+    try (Cursor cursor = MetaImpl.createCursor(cursorFactory, ROWS)) {
+      List<Cursor.Accessor> accessors =
+          cursor.createAccessors(columnsMetaDataList, Unsafe.localCalendar(), null);
+
+      assertEquals(columnsMetaDataList.size(), accessors.size());
+      Cursor.Accessor intAccessor = accessors.get(0);
+      Cursor.Accessor strAccessor = accessors.get(1);
+      Cursor.Accessor doubleAccessor = accessors.get(2);
+
+      for (Object row : ROWS) {
+        assertTrue(cursor.next());
+        SimplePOJO pjo = (SimplePOJO) row;
+        assertEquals(pjo.intField, intAccessor.getObject());
+        assertEquals(pjo.stringField, strAccessor.getObject());
+        assertEquals(pjo.doubleField, doubleAccessor.getObject());
+      }
+
+      assertFalse(cursor.next());
+    }
+  }
+
+  /**
+   * Deducing the cursor when columns are the fields of a Java object,
+   * different columns ordering.
+   */
+  @Test public void deduceRecordCursorFactoryDifferentFieldsOrdering() throws Exception {
+    List<ColumnMetaData> columnsMetaDataList = Arrays.asList(
+        MetaImpl.columnMetaData("stringField", 2, STRING_TYPE, true),
+        MetaImpl.columnMetaData("doubleField", 3, DOUBLE_TYPE, true),
+        MetaImpl.columnMetaData("intField", 1, INT_TYPE, true));
+
+    Meta.CursorFactory cursorFactory =
+        Meta.CursorFactory.deduce(columnsMetaDataList, SimplePOJO.class);
+
+    try (Cursor cursor = MetaImpl.createCursor(cursorFactory, ROWS)) {
+      List<Cursor.Accessor> accessors =
+          cursor.createAccessors(columnsMetaDataList, Unsafe.localCalendar(), null);
+
+      assertEquals(columnsMetaDataList.size(), accessors.size());
+      Cursor.Accessor strAccessor = accessors.get(0);
+      Cursor.Accessor doubleAccessor = accessors.get(1);
+      Cursor.Accessor intAccessor = accessors.get(2);
+
+      for (Object row : ROWS) {
+        assertTrue(cursor.next());
+        SimplePOJO pjo = (SimplePOJO) row;
+        assertEquals(pjo.intField, intAccessor.getObject());
+        assertEquals(pjo.stringField, strAccessor.getObject());
+        assertEquals(pjo.doubleField, doubleAccessor.getObject());
+      }
+
+      assertFalse(cursor.next());
+    }
+  }
+
+  /**
+   * Deducing the cursor when columns are (a subset of) the fields of a Java object.
+   */
+  @Test public void deduceRecordCursorFactoryProjectedFields() throws Exception {
+    List<ColumnMetaData> columnsMetaDataList = Arrays.asList(
+        MetaImpl.columnMetaData("stringField", 1, STRING_TYPE, true),
+        MetaImpl.columnMetaData("doubleField", 2, DOUBLE_TYPE, true));
+
+    Meta.CursorFactory cursorFactory =
+        Meta.CursorFactory.deduce(columnsMetaDataList, SimplePOJO.class);
+
+    try (Cursor cursor = MetaImpl.createCursor(cursorFactory, ROWS)) {
+      List<Cursor.Accessor> accessors =
+          cursor.createAccessors(columnsMetaDataList, Unsafe.localCalendar(), null);
+
+      assertEquals(columnsMetaDataList.size(), accessors.size());
+      Cursor.Accessor strAccessor = accessors.get(0);
+      Cursor.Accessor doubleAccessor = accessors.get(1);
+
+      for (Object row : ROWS) {
+        assertTrue(cursor.next());
+        SimplePOJO pjo = (SimplePOJO) row;
+        assertEquals(pjo.stringField, strAccessor.getObject());
+        assertEquals(pjo.doubleField, doubleAccessor.getObject());
+      }
+
+      assertFalse(cursor.next());
+    }
+  }
+}
+
+// End CursorFactoryDeduceTest.java

--- a/core/src/test/java/org/apache/calcite/avatica/MetaImplCollectTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/MetaImplCollectTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica;
+
+import org.junit.Test;
+
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.calcite.avatica.CursorFactoryDeduceTest.DOUBLE_TYPE;
+import static org.apache.calcite.avatica.CursorFactoryDeduceTest.INT_TYPE;
+import static org.apache.calcite.avatica.CursorFactoryDeduceTest.ROWS;
+import static org.apache.calcite.avatica.CursorFactoryDeduceTest.STRING_TYPE;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@code MetaImpl} relative to the {@code collect} method.
+ */
+public class MetaImplCollectTest {
+
+  /**
+   * Collecting from records where columns are the fields of a Java object.
+   */
+  @Test
+  public void collectRecord() {
+    List<ColumnMetaData> columnsMetaDataList = Arrays.asList(
+        MetaImpl.columnMetaData("stringField", 2, STRING_TYPE, true),
+        MetaImpl.columnMetaData("doubleField", 3, DOUBLE_TYPE, true),
+        MetaImpl.columnMetaData("intField", 1, INT_TYPE, true));
+
+    Meta.CursorFactory cursorFactory =
+        Meta.CursorFactory.deduce(columnsMetaDataList, CursorFactoryDeduceTest.SimplePOJO.class);
+
+    List<List<Object>> rows = new ArrayList<>();
+    MetaImpl.collect(cursorFactory, ROWS, rows);
+
+    for (int i = 0; i < ROWS.size(); i++) {
+      CursorFactoryDeduceTest.SimplePOJO inputRow =
+          (CursorFactoryDeduceTest.SimplePOJO) ROWS.get(i);
+      List<Object> collectedRow = rows.get(i);
+      assertEquals(inputRow.stringField, collectedRow.get(0));
+      assertEquals(inputRow.doubleField, collectedRow.get(1));
+      assertEquals(inputRow.intField, collectedRow.get(2));
+    }
+  }
+
+  /**
+   * Collecting from records where columns are (a subset of) the fields of a Java object.
+   */
+  @Test public void collectProjectedRecord() {
+    List<ColumnMetaData> columnsMetaDataList = Arrays.asList(
+        MetaImpl.columnMetaData("stringField", 2, STRING_TYPE, true),
+        MetaImpl.columnMetaData("doubleField", 3, DOUBLE_TYPE, true));
+
+    Meta.CursorFactory cursorFactory =
+        Meta.CursorFactory.deduce(columnsMetaDataList, CursorFactoryDeduceTest.SimplePOJO.class);
+
+    List<List<Object>> rows = new ArrayList<>();
+    MetaImpl.collect(cursorFactory, ROWS, rows);
+
+    for (int i = 0; i < ROWS.size(); i++) {
+      CursorFactoryDeduceTest.SimplePOJO inputRow =
+          (CursorFactoryDeduceTest.SimplePOJO) ROWS.get(i);
+      List<Object> collectedRow = rows.get(i);
+      assertEquals(inputRow.stringField, collectedRow.get(0));
+      assertEquals(inputRow.doubleField, collectedRow.get(1));
+    }
+  }
+
+  /**
+   * Collect from a single column having a Java object as type.
+   */
+  @Test public void collectObject() {
+    ColumnMetaData.Rep rep = ColumnMetaData.Rep.of(CursorFactoryDeduceTest.SimplePOJO.class);
+    ColumnMetaData.AvaticaType pojoType =
+        ColumnMetaData.scalar(Types.OTHER, "OTHER", rep);
+
+    ColumnMetaData pojoMetadata =
+        MetaImpl.columnMetaData("POJO", 1, pojoType, true);
+
+    List<ColumnMetaData> columnMetaDataList = Collections.singletonList(pojoMetadata);
+
+    Meta.CursorFactory cursorFactory =
+        Meta.CursorFactory.deduce(columnMetaDataList, CursorFactoryDeduceTest.SimplePOJO.class);
+
+    List<List<Object>> rows = new ArrayList<>();
+    MetaImpl.collect(cursorFactory, ROWS, rows);
+
+    for (int i = 0; i < ROWS.size(); i++) {
+      assertEquals(ROWS.get(i), rows.get(i).get(0));
+    }
+  }
+}
+
+// End MetaImplCollectTest.java

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -29,6 +29,15 @@ Downloads are available on the
 [downloads page]({{ site.baseurl }}/downloads/avatica.html).
 
 
+[<a href="https://issues.apache.org/jira/browse/CALCITE-2489">CALCITE-2489</a>] Order of fields in JavaTypeFactoryImpl#createStructType is unstable
+
+The commit introduces the following breaking change.
+
+`Meta#deduce(List<ColumnMetaData> columns, Class resultClazz)` now only derives the order of the fields from the list of provided column metadata `columns` when generating a record from the given Java class `resultClazz`, instead of relying on the field order provided by `Object#getFields()`, which is a JVM-dependent feature.
+
+Before, the field names where not checked against the field names of the provided class. Now, if `resultClazz` is not null, the provided field names are expected to match existing fields in that class. If a column metadata has name `column`, and no public field in `resultClazz` with that name exists, the following exception is thrown:
+`java.lang.RuntimeException: java.lang.NoSuchFieldException: C`.
+
 ## <a href="https://github.com/apache/calcite-avatica/releases/tag/rel/avatica-1.17.0">1.17.0</a> / 2020-06-22
 {: #v1-17-0}
 


### PR DESCRIPTION
…e is unstable

The changes in the PR are meant to allow us to "pass" the field ordering and avoid any call to Class.getFields(), which is problematic as it's JVM dependent.

More details are available in the [ML discussion](https://lists.apache.org/thread.html/r7537572f56fe2d734baad2de7fdeda490deb520febc3072c60e79de0%40%3Cdev.calcite.apache.org%3E)

EDIT: let me provide a more detailed description/overview to ease the reviewing process.

The PR introduces a deprecation annotation for method 
```
public RecordIteratorCursor(Iterator<E> iterator, Class<E> clazz) {
    this(iterator, clazz, Arrays.asList(clazz.getFields()));
}
```
This is necessary to adopt a Calcite-specific and deterministic/stable fields ordering.
This is possible by passing the fields (in the sought order) via `RecordIteratorCursor(Iterator, Class, List)`, as already done for record with projected columns (in order to know what to keep/drop a List of fields is explicitly passed).

In order to use the same method for generic records (projected and non-projected), `Meta.java` had to be updated, to make some methods more generic (they were "hard-coding"  `Style.RECORD_PROJECTION` as it was the only expected user of those methods, while now we want a `Style` parameter to accommodate both `Style.RECORD_PROJECTION` and `Style.RECORD`).

The only "glitch" is that `MetaImpl` internal classes (to expose different metadata, the catalog etc.) have columns not matching the field names (they are in capital letters, etc.).
On Calcite side it suffices to pass `null` instead of the class name for those classes (it's a single call in Calcite, I have already tried that locally), so the code won't try to validate the column names against the class fields (only done when a class is provided, it's a "sanity check", but the precondition is to have obtained the column names from the class fields, which is not the case for those internal classes).

So, as per the comment in the code, once we merge `CALCITE-2489` in Calcite codebase we can drop the ugly `if` statement.

Changes in `MetaImpl.java`, are simply taking advantage of the more general signature of some methods in `Meta.java`, where the code had to differentiate between `Style.RECORD_PROJECTION` and `Style.RECORD`, now we can call a single method.