### PR TITLE
[CALCITE-4573] Fix  close AvaticaResultSet  will throw NPE bug

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaResultSet.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaResultSet.java
@@ -153,7 +153,7 @@ public class AvaticaResultSet extends ArrayFactoryImpl implements ResultSet {
       this.cursor = null;
       cursor.close();
     }
-    if(statement != null) {
+    if (statement != null) {
       statement.onResultSetClose(this);
     }
   }

--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaResultSet.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaResultSet.java
@@ -153,7 +153,9 @@ public class AvaticaResultSet extends ArrayFactoryImpl implements ResultSet {
       this.cursor = null;
       cursor.close();
     }
-    statement.onResultSetClose(this);
+    if(statement != null) {
+      statement.onResultSetClose(this);
+    }
   }
 
   /** Sets the flag to indicate that cancel has been requested.

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatementTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatementTest.java
@@ -72,8 +72,7 @@ public class AvaticaClosedResultSetWithNullStatementTest extends AvaticaClosedTe
         AvaticaClosedResultSetWithNullStatementTest::methodVerifier);
   }
 
-  public AvaticaClosedResultSetWithNullStatementTest(Method method,
-                                                     MethodVerifier verifier) {
+  public AvaticaClosedResultSetWithNullStatementTest(Method method, MethodVerifier verifier) {
     super(method, verifier);
   }
 

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatementTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatementTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@code AvaticaResultSet} relative to close behavior
  */
 @RunWith(Parameterized.class)
-public class AvaticaClosedResultSetWithNullStatmentTest extends AvaticaClosedTestBase<ResultSet> {
+public class AvaticaClosedResultSetWithNullStatementTest extends AvaticaClosedTestBase<ResultSet> {
   // Mapping between Connection method and the verifier to check close behavior
   private static MethodVerifier methodVerifier(Method method) {
     String name = method.getName();
@@ -68,11 +68,11 @@ public class AvaticaClosedResultSetWithNullStatmentTest extends AvaticaClosedTes
 
   @Parameters(name = "{index}: {0}")
   public static Iterable<? extends Object[]> getParameters() {
-    return getMethodsToTest(ResultSet.class, AvaticaResultSet.class, METHOD_FILTER, AvaticaClosedResultSetWithNullStatmentTest::methodVerifier);
+    return getMethodsToTest(ResultSet.class, AvaticaResultSet.class, METHOD_FILTER, AvaticaClosedResultSetWithNullStatementTest::methodVerifier);
   }
 
-  public AvaticaClosedResultSetWithNullStatmentTest(Method method,
-      MethodVerifier verifier) {
+  public AvaticaClosedResultSetWithNullStatementTest(Method method,
+                                                     MethodVerifier verifier) {
     super(method, verifier);
   }
 
@@ -88,4 +88,4 @@ public class AvaticaClosedResultSetWithNullStatmentTest extends AvaticaClosedTes
   }
 }
 
-// End AvaticaClosedResultSetTest.java
+// End AvaticaClosedResultSetWithNullStatementTest.java

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatementTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatementTest.java
@@ -68,7 +68,8 @@ public class AvaticaClosedResultSetWithNullStatementTest extends AvaticaClosedTe
 
   @Parameters(name = "{index}: {0}")
   public static Iterable<? extends Object[]> getParameters() {
-    return getMethodsToTest(ResultSet.class, AvaticaResultSet.class, METHOD_FILTER, AvaticaClosedResultSetWithNullStatementTest::methodVerifier);
+    return getMethodsToTest(ResultSet.class, AvaticaResultSet.class, METHOD_FILTER,
+        AvaticaClosedResultSetWithNullStatementTest::methodVerifier);
   }
 
   public AvaticaClosedResultSetWithNullStatementTest(Method method,

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatmentTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatmentTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class AvaticaClosedResultSetWithNullStatmentTest extends AvaticaClosedTestBase<ResultSet> {
   // Mapping between Connection method and the verifier to check close behavior
-  private static final Function<Method, MethodVerifier> METHOD_MAPPING = method -> {
+  private static MethodVerifier methodVerifier(Method method) {
     String name = method.getName();
     // All update methods are not supported yet
     if (name.startsWith("update")) {
@@ -69,7 +69,7 @@ public class AvaticaClosedResultSetWithNullStatmentTest extends AvaticaClosedTes
 
   @Parameters(name = "{index}: {0}")
   public static Iterable<? extends Object[]> getParameters() {
-    return getMethodsToTest(ResultSet.class, AvaticaResultSet.class, METHOD_FILTER, METHOD_MAPPING);
+    return getMethodsToTest(ResultSet.class, AvaticaResultSet.class, METHOD_FILTER, AvaticaClosedResultSetWithNullStatmentTest::methodVerifier);
   }
 
   public AvaticaClosedResultSetWithNullStatmentTest(Method method, MethodVerifier verifier) {

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatmentTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatmentTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica;
+
+import org.apache.calcite.avatica.Meta.Signature;
+import org.apache.calcite.avatica.Meta.StatementHandle;
+import org.apache.calcite.avatica.util.DateTimeUtils;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.lang.reflect.Method;
+import java.sql.ResultSet;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.function.Function;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@code AvaticaResultSet} relative to close behavior
+ */
+@RunWith(Parameterized.class)
+public class AvaticaClosedResultSetWithNullStatmentTest extends AvaticaClosedTestBase<ResultSet> {
+  // Mapping between Connection method and the verifier to check close behavior
+  private static final Function<Method, MethodVerifier> METHOD_MAPPING = method -> {
+    String name = method.getName();
+    // All update methods are not supported yet
+    if (name.startsWith("update")) {
+      return ASSERT_UNSUPPORTED;
+    }
+
+    switch (name) {
+    case "absolute":
+    case "afterLast":
+    case "beforeFirst":
+    case "cancelRowUpdates":
+    case "deleteRow":
+    case "first":
+    case "getCursorName":
+    case "getRowId":
+    case "insertRow":
+    case "isLast":
+    case "last":
+    case "moveToCurrentRow":
+    case "moveToInsertRow":
+    case "previous":
+    case "refreshRow":
+    case "relative":
+      return ASSERT_UNSUPPORTED;
+
+    default:
+      return ASSERT_CLOSED;
+    }
+  };
+
+  @Parameters(name = "{index}: {0}")
+  public static Iterable<? extends Object[]> getParameters() {
+    return getMethodsToTest(ResultSet.class, AvaticaResultSet.class, METHOD_FILTER, METHOD_MAPPING);
+  }
+
+  public AvaticaClosedResultSetWithNullStatmentTest(Method method, MethodVerifier verifier) {
+    super(method, verifier);
+  }
+
+  @Override protected ResultSet newInstance() throws Exception {
+    Signature signature = new Signature(Collections.emptyList(), "", Collections.emptyList(),
+        Collections.emptyMap(), null, Meta.StatementType.SELECT);
+    AvaticaResultSet resultSet = new AvaticaResultSet(null, new QueryState(""), signature,
+        null, DateTimeUtils.UTC_ZONE, null);
+    resultSet.close();
+    assertTrue("Resultset is not closed", resultSet.isClosed());
+
+    return resultSet;
+  }
+}
+
+// End AvaticaClosedResultSetTest.java

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatmentTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatmentTest.java
@@ -26,7 +26,6 @@ import org.junit.runners.Parameterized.Parameters;
 import java.lang.reflect.Method;
 import java.sql.ResultSet;
 import java.util.Collections;
-import java.util.function.Function;
 
 import static org.junit.Assert.assertTrue;
 

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatmentTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatmentTest.java
@@ -17,7 +17,6 @@
 package org.apache.calcite.avatica;
 
 import org.apache.calcite.avatica.Meta.Signature;
-import org.apache.calcite.avatica.Meta.StatementHandle;
 import org.apache.calcite.avatica.util.DateTimeUtils;
 
 import org.junit.runner.RunWith;
@@ -27,11 +26,9 @@ import org.junit.runners.Parameterized.Parameters;
 import java.lang.reflect.Method;
 import java.sql.ResultSet;
 import java.util.Collections;
-import java.util.Properties;
 import java.util.function.Function;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@code AvaticaResultSet} relative to close behavior

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatmentTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedResultSetWithNullStatmentTest.java
@@ -71,7 +71,8 @@ public class AvaticaClosedResultSetWithNullStatmentTest extends AvaticaClosedTes
     return getMethodsToTest(ResultSet.class, AvaticaResultSet.class, METHOD_FILTER, AvaticaClosedResultSetWithNullStatmentTest::methodVerifier);
   }
 
-  public AvaticaClosedResultSetWithNullStatmentTest(Method method, MethodVerifier verifier) {
+  public AvaticaClosedResultSetWithNullStatmentTest(Method method,
+      MethodVerifier verifier) {
     super(method, verifier);
   }
 


### PR DESCRIPTION
Fix bug [\[CALCITE-4573\]](https://issues.apache.org/jira/browse/CALCITE-4573)
## Problem:
In `ArrayFactoryImpl.create(AvaticaType elementType, Iterable<Object> elements)` method, we will create AvaticaResultSet with a null statement, However in the `close()` menthod  for AvaticaResultSet, it doesn't valid null situation before we call ` statement.onResultSetClose(this);`, which cause npe exception.

## Solution:
add check for statement in  `close()` method

## Key changed/added classes in this PR   
- `org.apache.calcite.avatica.AvaticaResultSet`


