### PR TITLE
[CALCITE-4600] Support Date/Time/Timestamp slot object's content for date/time/timestamp array accessors

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
@@ -908,15 +908,15 @@ public abstract class AbstractCursor implements Cursor {
     }
 
     @Override public Date getDate(Calendar calendar) throws SQLException {
-      final Number v = getDate();
+      final Number v = getNumber();
       if (v == null) {
         return null;
       }
-      return longToDate(((Number) v).longValue() * DateTimeUtils.MILLIS_PER_DAY, calendar);
+      return longToDate(v.longValue() * DateTimeUtils.MILLIS_PER_DAY, calendar);
     }
 
     @Override public Timestamp getTimestamp(Calendar calendar) throws SQLException {
-      final Number v = getDate();
+      final Number v = getNumber();
       if (v == null) {
         return null;
       }
@@ -925,14 +925,14 @@ public abstract class AbstractCursor implements Cursor {
     }
 
     @Override public String getString() throws SQLException {
-      final Number v = getDate();
+      final Number v = getNumber();
       if (v == null) {
         return null;
       }
       return dateAsString(v.intValue(), null);
     }
 
-    protected Number getDate() throws SQLException {
+    protected Number getNumber() throws SQLException {
       final Object value = super.getObject();
       if (value == null) {
         return null;

--- a/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
@@ -908,15 +908,15 @@ public abstract class AbstractCursor implements Cursor {
     }
 
     @Override public Date getDate(Calendar calendar) throws SQLException {
-      final Number v = getNumber();
+      final Number v = getDate();
       if (v == null) {
         return null;
       }
-      return longToDate(v.longValue() * DateTimeUtils.MILLIS_PER_DAY, calendar);
+      return longToDate(((Number) v).longValue() * DateTimeUtils.MILLIS_PER_DAY, calendar);
     }
 
     @Override public Timestamp getTimestamp(Calendar calendar) throws SQLException {
-      final Number v = getNumber();
+      final Number v = getDate();
       if (v == null) {
         return null;
       }
@@ -925,11 +925,22 @@ public abstract class AbstractCursor implements Cursor {
     }
 
     @Override public String getString() throws SQLException {
-      final Number v = getNumber();
+      final Number v = getDate();
       if (v == null) {
         return null;
       }
       return dateAsString(v.intValue(), null);
+    }
+
+    protected Number getDate() throws SQLException {
+      final Object value = super.getObject();
+      if (value == null) {
+        return null;
+      }
+      if (value instanceof Date) {
+        return ((Date) value).toLocalDate().toEpochDay();
+      }
+      return (Number) value;
     }
   }
 
@@ -973,6 +984,17 @@ public abstract class AbstractCursor implements Cursor {
       }
       return timeAsString(v.intValue(), null);
     }
+
+    protected Number getNumber() throws SQLException {
+      final Object v = super.getObject();
+      if (v == null) {
+        return null;
+      }
+      if (v instanceof Time) {
+        return ((Time) v).getTime();
+      }
+      return (Number) v;
+    }
   }
 
   /**
@@ -1001,7 +1023,7 @@ public abstract class AbstractCursor implements Cursor {
     }
 
     @Override public Date getDate(Calendar calendar) throws SQLException {
-      final Timestamp timestamp  = getTimestamp(calendar);
+      final Timestamp timestamp = getTimestamp(calendar);
       if (timestamp == null) {
         return null;
       }
@@ -1009,7 +1031,7 @@ public abstract class AbstractCursor implements Cursor {
     }
 
     @Override public Time getTime(Calendar calendar) throws SQLException {
-      final Timestamp timestamp  = getTimestamp(calendar);
+      final Timestamp timestamp = getTimestamp(calendar);
       if (timestamp == null) {
         return null;
       }
@@ -1024,6 +1046,17 @@ public abstract class AbstractCursor implements Cursor {
         return null;
       }
       return timestampAsString(v.longValue(), null);
+    }
+
+    protected Number getNumber() throws SQLException {
+      final Object v = super.getObject();
+      if (v == null) {
+        return null;
+      }
+      if (v instanceof Timestamp) {
+        return ((Timestamp) v).getTime();
+      }
+      return (Number) v;
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
@@ -942,7 +942,9 @@ public abstract class AbstractCursor implements Cursor {
         return null;
       }
       if (value instanceof Date) {
-        return ((Date) value).toLocalDate().toEpochDay();
+        long time = ((Date) value).getTime();
+        time -= localCalendar.getTimeZone().getOffset(time);
+        return time / DateTimeUtils.MILLIS_PER_DAY;
       }
       return (Number) value;
     }

--- a/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
@@ -694,11 +694,15 @@ public abstract class AbstractCursor implements Cursor {
     }
 
     public BigDecimal getBigDecimal(int scale) throws SQLException {
-      return (BigDecimal) getObject();
+      Number number = getNumber();
+      return number == null || number instanceof BigDecimal
+          ? (BigDecimal) number : BigDecimal.valueOf(number.longValue());
     }
 
     public BigDecimal getBigDecimal() throws SQLException {
-      return (BigDecimal) getObject();
+      Number number = getNumber();
+      return number == null || number instanceof BigDecimal
+          ? (BigDecimal) number : BigDecimal.valueOf(number.longValue());
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/avatica/util/ArrayImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/ArrayImpl.java
@@ -227,11 +227,21 @@ public class ArrayImpl implements Array {
    * Elements are compared using {@link Object#equals(Object)}, and null
    * values are equal to each other. */
   public static boolean equalContents(Array left, Array right) throws SQLException {
+    if (left.getBaseType() != right.getBaseType()) {
+      return false;
+    }
     ResultSet leftResultSet = left.getResultSet();
     ResultSet rightResultSet = right.getResultSet();
+    int leftColumnCount = leftResultSet.getMetaData().getColumnCount();
+    int rightColumnCount = rightResultSet.getMetaData().getColumnCount();
+    if (leftColumnCount != rightColumnCount) {
+      return false;
+    }
     while (leftResultSet.next() && rightResultSet.next()) {
-      if (!Objects.equals(leftResultSet.getObject(1), rightResultSet.getObject(1))) {
-        return false;
+      for (int i = 1; i <= leftColumnCount; i++) {
+        if (!Objects.equals(leftResultSet.getObject(i), rightResultSet.getObject(i))) {
+          return false;
+        }
       }
     }
     return !leftResultSet.next() && !rightResultSet.next();

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
@@ -194,6 +194,13 @@ public class AvaticaResultSetConversionsTest {
                       ColumnMetaData.Rep.NUMBER),
                   "ARRAY",
                   ColumnMetaData.Rep.ARRAY),
+              DatabaseMetaData.columnNoNulls),
+          columnMetaData("decimal_array", 16,
+              ColumnMetaData.array(
+                  ColumnMetaData.scalar(Types.DECIMAL, "DECIMAL",
+                      ColumnMetaData.Rep.PRIMITIVE_DOUBLE),
+                  "ARRAY",
+                  ColumnMetaData.Rep.ARRAY),
               DatabaseMetaData.columnNoNulls));
 
       List<Object> row = Collections.<Object>singletonList(
@@ -205,7 +212,8 @@ public class AvaticaResultSetConversionsTest {
               new StructImpl(Arrays.asList(42, false)),
               Arrays.asList(123, 18234),
               Arrays.asList(1476130718123L, 1479123123242L),
-              Arrays.asList(1476123L, 147912242L)
+              Arrays.asList(1476123L, 147912242L),
+              Arrays.asList(1, 1.1)
           });
 
       CursorFactory factory = CursorFactory.deduce(columns, null);
@@ -581,6 +589,24 @@ public class AvaticaResultSetConversionsTest {
       Array expectedArray =
           new ArrayFactoryImpl(Unsafe.localCalendar().getTimeZone()).createArray(
               intType, Arrays.asList(1, 2, 3));
+      assertTrue(ArrayImpl.equalContents(expectedArray, g.getArray(resultSet)));
+    }
+  }
+
+  /**
+   * Accessor test helper for decimal array column.
+   */
+  private static final class DecimalArrayAccessorTestHelper extends AccessorTestHelper {
+    private DecimalArrayAccessorTestHelper(Getter g) {
+      super(g);
+    }
+
+    @Override public void testGetArray(ResultSet resultSet) throws SQLException {
+      ColumnMetaData.ScalarType intType =
+          ColumnMetaData.scalar(Types.DECIMAL, "DECIMAL", ColumnMetaData.Rep.PRIMITIVE_DOUBLE);
+      Array expectedArray =
+          new ArrayFactoryImpl(Unsafe.localCalendar().getTimeZone()).createArray(
+              intType, Arrays.asList(1, 1.1));
       assertTrue(ArrayImpl.equalContents(expectedArray, g.getArray(resultSet)));
     }
   }
@@ -1118,7 +1144,9 @@ public class AvaticaResultSetConversionsTest {
         new TimestampArrayAccessorTestHelper(new OrdinalGetter(15)),
         new TimestampArrayAccessorTestHelper(new LabelGetter("timestamp_array")),
         new TimeArrayAccessorTestHelper(new OrdinalGetter(16)),
-        new TimeArrayAccessorTestHelper(new LabelGetter("time_array")));
+        new TimeArrayAccessorTestHelper(new LabelGetter("time_array")),
+        new DecimalArrayAccessorTestHelper(new OrdinalGetter(17)),
+        new DecimalArrayAccessorTestHelper(new LabelGetter("decimal_array")));
   }
 
   private final AccessorTestHelper testHelper;

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
@@ -57,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.TimeZone;
 
 import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;
@@ -172,6 +173,27 @@ public class AvaticaResultSetConversionsTest {
                           ColumnMetaData.scalar(Types.BOOLEAN, "BOOLEAN",
                               ColumnMetaData.Rep.PRIMITIVE_BOOLEAN),
                           DatabaseMetaData.columnNoNulls))),
+              DatabaseMetaData.columnNoNulls),
+          columnMetaData("date_array", 13,
+              ColumnMetaData.array(
+                  ColumnMetaData.scalar(Types.DATE, "DATE",
+                      ColumnMetaData.Rep.PRIMITIVE_INT),
+                  "ARRAY",
+                  ColumnMetaData.Rep.ARRAY),
+              DatabaseMetaData.columnNoNulls),
+          columnMetaData("timestamp_array", 14,
+              ColumnMetaData.array(
+                  ColumnMetaData.scalar(Types.TIMESTAMP, "TIMESTAMP",
+                      ColumnMetaData.Rep.PRIMITIVE_LONG),
+                  "ARRAY",
+                  ColumnMetaData.Rep.ARRAY),
+              DatabaseMetaData.columnNoNulls),
+          columnMetaData("time_array", 15,
+              ColumnMetaData.array(
+                  ColumnMetaData.scalar(Types.TIME, "TIME",
+                      ColumnMetaData.Rep.NUMBER),
+                  "ARRAY",
+                  ColumnMetaData.Rep.ARRAY),
               DatabaseMetaData.columnNoNulls));
 
       List<Object> row = Collections.<Object>singletonList(
@@ -180,7 +202,10 @@ public class AvaticaResultSetConversionsTest {
               new Date(1476130718123L), new Time(1476130718123L),
               new Timestamp(1476130718123L),
               Arrays.asList(1, 2, 3),
-              new StructImpl(Arrays.asList(42, false))
+              new StructImpl(Arrays.asList(42, false)),
+              Arrays.asList(123, 18234),
+              Arrays.asList(1476130718123L, 1479123123242L),
+              Arrays.asList(1476123L, 147912242L)
           });
 
       CursorFactory factory = CursorFactory.deduce(columns, null);
@@ -556,6 +581,60 @@ public class AvaticaResultSetConversionsTest {
       Array expectedArray =
           new ArrayFactoryImpl(Unsafe.localCalendar().getTimeZone()).createArray(
               intType, Arrays.asList(1, 2, 3));
+      assertTrue(ArrayImpl.equalContents(expectedArray, g.getArray(resultSet)));
+    }
+  }
+
+  /**
+   * Accessor test helper for date array column.
+   */
+  private static final class DateArrayAccessorTestHelper extends AccessorTestHelper {
+    private DateArrayAccessorTestHelper(Getter g) {
+      super(g);
+    }
+
+    @Override public void testGetArray(ResultSet resultSet) throws SQLException {
+      ColumnMetaData.ScalarType intType =
+          ColumnMetaData.scalar(Types.DATE, "DATE", ColumnMetaData.Rep.PRIMITIVE_INT);
+      Array expectedArray =
+          new ArrayFactoryImpl(TimeZone.getTimeZone("UTC")).createArray(
+              intType, Arrays.asList(123, 18234));
+      assertTrue(ArrayImpl.equalContents(expectedArray, g.getArray(resultSet)));
+    }
+  }
+
+  /**
+   * Accessor test helper for time array column.
+   */
+  private static final class TimeArrayAccessorTestHelper extends AccessorTestHelper {
+    private TimeArrayAccessorTestHelper(Getter g) {
+      super(g);
+    }
+
+    @Override public void testGetArray(ResultSet resultSet) throws SQLException {
+      ColumnMetaData.ScalarType intType =
+          ColumnMetaData.scalar(Types.TIME, "TIME", ColumnMetaData.Rep.NUMBER);
+      Array expectedArray =
+          new ArrayFactoryImpl(TimeZone.getTimeZone("UTC")).createArray(
+              intType, Arrays.asList(1476123L, 147912242L));
+      assertTrue(ArrayImpl.equalContents(expectedArray, g.getArray(resultSet)));
+    }
+  }
+
+  /**
+   * Accessor test helper for timestamp array column.
+   */
+  private static final class TimestampArrayAccessorTestHelper extends AccessorTestHelper {
+    private TimestampArrayAccessorTestHelper(Getter g) {
+      super(g);
+    }
+
+    @Override public void testGetArray(ResultSet resultSet) throws SQLException {
+      ColumnMetaData.ScalarType intType =
+          ColumnMetaData.scalar(Types.TIMESTAMP, "TIMESTAMP", ColumnMetaData.Rep.PRIMITIVE_LONG);
+      Array expectedArray =
+          new ArrayFactoryImpl(TimeZone.getTimeZone("UTC")).createArray(
+              intType, Arrays.asList(1476130718123L, 1479123123242L));
       assertTrue(ArrayImpl.equalContents(expectedArray, g.getArray(resultSet)));
     }
   }
@@ -1033,7 +1112,13 @@ public class AvaticaResultSetConversionsTest {
         new ArrayAccessorTestHelper(new OrdinalGetter(12)),
         new ArrayAccessorTestHelper(new LabelGetter("array")),
         new StructAccessorTestHelper(new OrdinalGetter(13)),
-        new StructAccessorTestHelper(new LabelGetter("struct")));
+        new StructAccessorTestHelper(new LabelGetter("struct")),
+        new DateArrayAccessorTestHelper(new OrdinalGetter(14)),
+        new DateArrayAccessorTestHelper(new LabelGetter("date_array")),
+        new TimestampArrayAccessorTestHelper(new OrdinalGetter(15)),
+        new TimestampArrayAccessorTestHelper(new LabelGetter("timestamp_array")),
+        new TimeArrayAccessorTestHelper(new OrdinalGetter(16)),
+        new TimeArrayAccessorTestHelper(new LabelGetter("time_array")));
   }
 
   private final AccessorTestHelper testHelper;


### PR DESCRIPTION
In case of arrays of `date`, `time` and `timestamp` the content of `slot` object could be not only `Number` if the value is of not `JAVA_SQL_*` type ... At the same time avatica tries always to cast it to number and in case of 
```sql
select array[current_date];
select array[current_timestamp];
select array[current_time];
```
it leads to `ClassCastException` .
The PR  is aimed to fix such behavior by checking this type before 

