### PR TITLE
[CALCITE-2322] Add fetch row count support

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public abstract class AvaticaStatement
     implements Statement {
+
   /** The default value for {@link Statement#getFetchSize()}. */
   public static final int DEFAULT_FETCH_SIZE = 100;
 
@@ -108,6 +109,7 @@ public abstract class AvaticaStatement
     this.resultSetType = resultSetType;
     this.resultSetConcurrency = resultSetConcurrency;
     this.resultSetHoldability = resultSetHoldability;
+    this.fetchSize = connection.config().fetchSize(); // Default to connection config fetch size.
     this.signature = signature;
     this.closed = false;
     if (h == null) {

--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
@@ -67,7 +67,7 @@ public abstract class AvaticaStatement
   final int resultSetType;
   final int resultSetConcurrency;
   final int resultSetHoldability;
-  private int fetchSize = DEFAULT_FETCH_SIZE;
+  private int fetchRowCount;
   private int fetchDirection;
   protected long maxRowCount = 0;
 
@@ -109,7 +109,7 @@ public abstract class AvaticaStatement
     this.resultSetType = resultSetType;
     this.resultSetConcurrency = resultSetConcurrency;
     this.resultSetHoldability = resultSetHoldability;
-    this.fetchSize = connection.config().fetchSize(); // Default to connection config fetch size.
+    this.fetchRowCount = connection.config().fetchRowCount(); // Default to connection config fetch size.
     this.signature = signature;
     this.closed = false;
     if (h == null) {
@@ -409,12 +409,12 @@ public abstract class AvaticaStatement
 
   public void setFetchSize(int rows) throws SQLException {
     checkOpen();
-    this.fetchSize = rows;
+    this.fetchRowCount = rows;
   }
 
   public int getFetchSize() throws SQLException {
     checkOpen();
-    return fetchSize;
+    return fetchRowCount;
   }
 
   public int getResultSetConcurrency() throws SQLException {

--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
@@ -109,7 +109,7 @@ public abstract class AvaticaStatement
     this.resultSetType = resultSetType;
     this.resultSetConcurrency = resultSetConcurrency;
     this.resultSetHoldability = resultSetHoldability;
-    this.fetchRowCount = connection.config().fetchRowCount(); // Default to connection config fetch size.
+    this.fetchRowCount = connection.config().fetchRowCount(); // Default to connection config value
     this.signature = signature;
     this.closed = false;
     if (h == null) {

--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
@@ -36,7 +36,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public abstract class AvaticaStatement
     implements Statement {
-
   /** The default value for {@link Statement#getFetchSize()}. */
   public static final int DEFAULT_FETCH_SIZE = 100;
 

--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
@@ -67,7 +67,7 @@ public abstract class AvaticaStatement
   final int resultSetType;
   final int resultSetConcurrency;
   final int resultSetHoldability;
-  private int fetchRowCount;
+  private int fetchSizeRows;
   private int fetchDirection;
   protected long maxRowCount = 0;
 
@@ -109,7 +109,7 @@ public abstract class AvaticaStatement
     this.resultSetType = resultSetType;
     this.resultSetConcurrency = resultSetConcurrency;
     this.resultSetHoldability = resultSetHoldability;
-    this.fetchRowCount = connection.config().fetchRowCount(); // Default to connection config value
+    this.fetchSizeRows = connection.config().fetchSizeRows(); // Default to connection config value
     this.signature = signature;
     this.closed = false;
     if (h == null) {
@@ -409,12 +409,12 @@ public abstract class AvaticaStatement
 
   public void setFetchSize(int rows) throws SQLException {
     checkOpen();
-    this.fetchRowCount = rows;
+    this.fetchSizeRows = rows;
   }
 
   public int getFetchSize() throws SQLException {
     checkOpen();
-    return fetchRowCount;
+    return fetchSizeRows;
   }
 
   public int getResultSetConcurrency() throws SQLException {

--- a/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
+++ b/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
@@ -89,7 +89,7 @@ public enum BuiltInConnectionProperty implements ConnectionProperty {
       HostnameVerification.class, false),
 
   /** The number of rows to fetch per call, default is 100 rows. */
-  FETCH_ROW_COUNT("fetch_row_count", Type.NUMBER, AvaticaStatement.DEFAULT_FETCH_SIZE, false);
+  FETCH_SIZE_ROWS("fetch_size_rows", Type.NUMBER, AvaticaStatement.DEFAULT_FETCH_SIZE, false);
 
   private final String camelName;
   private final Type type;

--- a/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
+++ b/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
@@ -86,7 +86,10 @@ public enum BuiltInConnectionProperty implements ConnectionProperty {
   KEY_PASSWORD("key_password", Type.STRING, "", false),
 
   HOSTNAME_VERIFICATION("hostname_verification", Type.ENUM, HostnameVerification.STRICT,
-      HostnameVerification.class, false);
+      HostnameVerification.class, false),
+
+  /** Fetch size limit, default is 100 rows. */
+  FETCH_SIZE("fetch_size", Type.NUMBER, AvaticaStatement.DEFAULT_FETCH_SIZE, false);
 
   private final String camelName;
   private final Type type;

--- a/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
+++ b/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
@@ -88,8 +88,8 @@ public enum BuiltInConnectionProperty implements ConnectionProperty {
   HOSTNAME_VERIFICATION("hostname_verification", Type.ENUM, HostnameVerification.STRICT,
       HostnameVerification.class, false),
 
-  /** Fetch size limit, default is 100 rows. */
-  FETCH_SIZE("fetch_size", Type.NUMBER, AvaticaStatement.DEFAULT_FETCH_SIZE, false);
+  /** The number of rows to fetch per call, default is 100 rows. */
+  FETCH_ROW_COUNT("fetch_row_count", Type.NUMBER, AvaticaStatement.DEFAULT_FETCH_SIZE, false);
 
   private final String camelName;
   private final Type type;

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
@@ -62,7 +62,7 @@ public interface ConnectionConfig {
   String keyPassword();
   /** @see BuiltInConnectionProperty#HOSTNAME_VERIFICATION */
   HostnameVerification hostnameVerification();
-  /** @see BuiltInConnectionProperty#FETCH_SIZE */
+  /** @see BuiltInConnectionProperty#FETCH_ROW_COUNT */
   int fetchSize();
 }
 

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
@@ -62,8 +62,8 @@ public interface ConnectionConfig {
   String keyPassword();
   /** @see BuiltInConnectionProperty#HOSTNAME_VERIFICATION */
   HostnameVerification hostnameVerification();
-  /** @see BuiltInConnectionProperty#FETCH_ROW_COUNT */
-  int fetchRowCount();
+  /** @see BuiltInConnectionProperty#FETCH_SIZE_ROWS */
+  int fetchSizeRows();
 }
 
 // End ConnectionConfig.java

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
@@ -63,7 +63,7 @@ public interface ConnectionConfig {
   /** @see BuiltInConnectionProperty#HOSTNAME_VERIFICATION */
   HostnameVerification hostnameVerification();
   /** @see BuiltInConnectionProperty#FETCH_ROW_COUNT */
-  int fetchSize();
+  int fetchRowCount();
 }
 
 // End ConnectionConfig.java

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
@@ -62,6 +62,8 @@ public interface ConnectionConfig {
   String keyPassword();
   /** @see BuiltInConnectionProperty#HOSTNAME_VERIFICATION */
   HostnameVerification hostnameVerification();
+  /** @see BuiltInConnectionProperty#FETCH_SIZE */
+  int fetchSize();
 }
 
 // End ConnectionConfig.java

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
@@ -128,8 +128,8 @@ public class ConnectionConfigImpl implements ConnectionConfig {
         .getEnum(HostnameVerification.class);
   }
 
-  public int fetchRowCount() {
-    return BuiltInConnectionProperty.FETCH_ROW_COUNT.wrap(properties).getInt();
+  public int fetchSizeRows() {
+    return BuiltInConnectionProperty.FETCH_SIZE_ROWS.wrap(properties).getInt();
   }
 
   /** Converts a {@link Properties} object containing (name, value)

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
@@ -128,7 +128,7 @@ public class ConnectionConfigImpl implements ConnectionConfig {
         .getEnum(HostnameVerification.class);
   }
 
-  public int fetchSize() {
+  public int fetchRowCount() {
     return BuiltInConnectionProperty.FETCH_ROW_COUNT.wrap(properties).getInt();
   }
 

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
@@ -128,6 +128,10 @@ public class ConnectionConfigImpl implements ConnectionConfig {
         .getEnum(HostnameVerification.class);
   }
 
+  public int fetchSize() {
+    return BuiltInConnectionProperty.FETCH_SIZE.wrap(properties).getInt();
+  }
+
   /** Converts a {@link Properties} object containing (name, value)
    * pairs into a map whose keys are
    * {@link org.apache.calcite.avatica.InternalProperty} objects.

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
@@ -129,7 +129,7 @@ public class ConnectionConfigImpl implements ConnectionConfig {
   }
 
   public int fetchSize() {
-    return BuiltInConnectionProperty.FETCH_SIZE.wrap(properties).getInt();
+    return BuiltInConnectionProperty.FETCH_ROW_COUNT.wrap(properties).getInt();
   }
 
   /** Converts a {@link Properties} object containing (name, value)

--- a/core/src/main/java/org/apache/calcite/avatica/MetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/MetaImpl.java
@@ -1589,7 +1589,7 @@ public abstract class MetaImpl implements Meta {
         }
         try {
           // currentOffset updated after element is read from `rows` iterator
-          frame = fetch(stmt.handle, currentOffset, AvaticaStatement.DEFAULT_FETCH_SIZE);
+          frame = fetch(stmt.handle, currentOffset, stmt.getFetchSize());
         } catch (NoSuchStatementException e) {
           resetStatement();
           // re-fetch the batch where we left off

--- a/site/_docs/client_reference.md
+++ b/site/_docs/client_reference.md
@@ -173,11 +173,11 @@ on-hover images for the permalink, but oh well.
 
 : _Required_: Only if `truststore` was provided.
 
-<strong><a name="fetch_row_count" href="#fetch_row_count">fetch_row_count</a></strong>
+<strong><a name="fetch_size_rows" href="#fetch_size_rows">fetch_size_rows</a></strong>
 
 : _Description_: The number of rows to fetch. If
     <a href="https://docs.oracle.com/javase/8/docs/api/java/sql/Statement.html#setFetchSize-int-">
-    Statement:setFetchSize</a> is set, that value overrides fetch_row_count.
+    Statement:setFetchSize</a> is set, that value overrides fetch_size_rows.
 
 : _Default_: `100`.
 

--- a/site/_docs/client_reference.md
+++ b/site/_docs/client_reference.md
@@ -175,7 +175,9 @@ on-hover images for the permalink, but oh well.
 
 <strong><a name="fetch_row_count" href="#fetch_row_count">fetch_row_count</a></strong>
 
-: _Description_: The number of rows to fetch
+: _Description_: The number of rows to fetch. If
+    <a href="https://docs.oracle.com/javase/8/docs/api/java/sql/Statement.html#setFetchSize-int-">
+    Statement:setFetchSize</a> is set, that value overrides fetch_row_count.
 
 : _Default_: `100`.
 

--- a/site/_docs/client_reference.md
+++ b/site/_docs/client_reference.md
@@ -172,3 +172,11 @@ on-hover images for the permalink, but oh well.
 : _Default_: `null`.
 
 : _Required_: Only if `truststore` was provided.
+
+<strong><a name="fetch_row_count" href="#fetch_row_count">fetch_row_count</a></strong>
+
+: _Description_: The number of rows to fetch
+
+: _Default_: `100`.
+
+: _Required_: No.


### PR DESCRIPTION
This resurrects https://github.com/apache/calcite-avatica/pull/49, updating @kminder 's existing work per guidance from [CALCITE-2322](https://issues.apache.org/jira/browse/CALCITE-2322?focusedCommentId=17370941&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17370941). 

The purpose of this change is to add support for configurable "fetch size"/ "fetch row count". Currently, setting [fetchSize](https://docs.oracle.com/javase/8/docs/api/java/sql/Statement.html#setFetchSize-int-) has no effect, because avatica always uses a hardcoded default value. This PR resolves that issue. 