### PR TITLE
[CALCITE-4767] Add Quoting.BQ_BACK_TICK to support BQ identifier syntax

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/util/Quoting.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/Quoting.java
@@ -21,8 +21,15 @@ public enum Quoting {
   /** Quote identifiers in double-quotes. For example, {@code "my id"}. */
   DOUBLE_QUOTE("\""),
 
-  /** Quote identifiers in back-quotes. For example, {@code `my id`}. */
+  /** Quote identifiers in back-quotes and use back-quotes to escape back-quotes.
+   * For example, {@code `my ``id```}.
+   */
   BACK_TICK("`"),
+
+  /** Quote identifiers in back-quotes and use backslash to escape back-quotes.
+   *  For example, {@code `my \`id\``}.
+   */
+  BQ_BACK_TICK("`"),
 
   /** Quote identifiers in brackets. For example, {@code [my id]}. */
   BRACKET("[");


### PR DESCRIPTION
BigQuery uses `` \` `` to escape backticks in identifiers, instead of the usual ` `` `. We need a separate `Quoting` enum value to allow the Calcite SQL parser to distinguish between these syntaxes.

See CALCITE-4767 for more details.