### PR TITLE
Site: Change the javadoc title to Apache Calcite Avatica API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -246,8 +246,8 @@ allprojects {
                 docEncoding = "UTF-8"
                 charSet = "UTF-8"
                 encoding = "UTF-8"
-                docTitle = "Apache Calcite Avatica ${project.name} API"
-                windowTitle = "Apache Calcite Avatica ${project.name} API"
+                docTitle = "Apache Calcite Avatica API"
+                windowTitle = "Apache Calcite Avatica API"
                 header = "<b>Apache Calcite Avatica</b>"
                 bottom =
                     "Copyright &copy; 2012-$lastEditYear Apache Software Foundation. All Rights Reserved."


### PR DESCRIPTION
The doc title should be " Apache Calcite Avatica API", but is "Apache Calcite Avatica calcite-avatica API".