### PR TITLE
CALCITE-5009 Transparent JDBC connection re-creation may lead to data…

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
@@ -66,6 +66,7 @@ public abstract class AvaticaConnection implements Connection {
    * the number of rows modified. */
   public static final String ROWCOUNT_COLUMN_NAME = "ROWCOUNT";
 
+  //TODO shouldn't we move this to BuiltInConnectionProperty ?
   public static final String NUM_EXECUTE_RETRIES_KEY = "avatica.statement.retries";
   public static final String NUM_EXECUTE_RETRIES_DEFAULT = "5";
 
@@ -96,6 +97,7 @@ public abstract class AvaticaConnection implements Connection {
   public final Map<Integer, AvaticaStatement> statementMap = new ConcurrentHashMap<>();
   final Map<Integer, AtomicBoolean> flagMap = new ConcurrentHashMap<>();
   protected final long maxRetriesPerExecute;
+  protected final boolean transparentReconnectEnabled;
 
   /**
    * Creates an AvaticaConnection.
@@ -127,6 +129,7 @@ public abstract class AvaticaConnection implements Connection {
       throw new RuntimeException(e);
     }
     this.maxRetriesPerExecute = getNumStatementRetries(info);
+    this.transparentReconnectEnabled = config().transparentReconnectionEnabled();
   }
 
   /** Computes the number of retries
@@ -792,7 +795,8 @@ public abstract class AvaticaConnection implements Connection {
         return callable.call();
       } catch (AvaticaClientRuntimeException e) {
         lastException = e;
-        if (ErrorResponse.MISSING_CONNECTION_ERROR_CODE == e.getErrorCode()) {
+        if (ErrorResponse.MISSING_CONNECTION_ERROR_CODE == e.getErrorCode()
+                && transparentReconnectEnabled) {
           this.openConnection();
           continue;
         }

--- a/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
+++ b/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
@@ -86,7 +86,9 @@ public enum BuiltInConnectionProperty implements ConnectionProperty {
   KEY_PASSWORD("key_password", Type.STRING, "", false),
 
   HOSTNAME_VERIFICATION("hostname_verification", Type.ENUM, HostnameVerification.STRICT,
-      HostnameVerification.class, false);
+      HostnameVerification.class, false),
+
+  TRANSPARENT_RECONNECTION("transparent_reconnection", Type.BOOLEAN, Boolean.FALSE, false);
 
   private final String camelName;
   private final Type type;

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
@@ -62,6 +62,8 @@ public interface ConnectionConfig {
   String keyPassword();
   /** @see BuiltInConnectionProperty#HOSTNAME_VERIFICATION */
   HostnameVerification hostnameVerification();
+  /** @see BuiltInConnectionProperty#TRANSPARENT_RECONNECTION */
+  boolean transparentReconnectionEnabled();
 }
 
 // End ConnectionConfig.java

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
@@ -128,6 +128,11 @@ public class ConnectionConfigImpl implements ConnectionConfig {
         .getEnum(HostnameVerification.class);
   }
 
+  @Override public boolean transparentReconnectionEnabled() {
+    return BuiltInConnectionProperty.TRANSPARENT_RECONNECTION.wrap(properties)
+       .getBoolean();
+  }
+
   /** Converts a {@link Properties} object containing (name, value)
    * pairs into a map whose keys are
    * {@link org.apache.calcite.avatica.InternalProperty} objects.


### PR DESCRIPTION
… loss

Change-Id: Iaf10b6e4d4760cce9a7fabf1762a94501684f23d