### PR TITLE
[closed]CALCITE-5358/ Add in HTTP_BAD_REQUEST

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/remote/AbstractHandler.java
+++ b/core/src/main/java/org/apache/calcite/avatica/remote/AbstractHandler.java
@@ -110,6 +110,13 @@ public abstract class AbstractHandler<T> implements Handler<T> {
   }
 
   /**
+   * Attempts to convert an Exception to an ErrorResponse with an HTTP status code of {@code 400}.
+   */
+  public HandlerResponse<T> badRequestErrorResponse(Exception e) {
+    return createErrorResponse(e, HTTP_BAD_REQUEST);
+  }
+
+  /**
    * Attempts to convert an Exception to an ErrorResponse with an HTTP status code of {@code 401}.
    */
   public HandlerResponse<T> unauthenticatedErrorResponse(Exception e) {

--- a/core/src/main/java/org/apache/calcite/avatica/remote/Handler.java
+++ b/core/src/main/java/org/apache/calcite/avatica/remote/Handler.java
@@ -27,6 +27,7 @@ import java.util.Objects;
  */
 public interface Handler<T> {
   int HTTP_OK = 200;
+  int HTTP_BAD_REQUEST = 400;
   int HTTP_UNAUTHENTICATED = 401;
   int HTTP_UNAUTHORIZED = 403;
   int HTTP_INTERNAL_SERVER_ERROR = 500;

--- a/server/src/main/java/org/apache/calcite/avatica/server/AvaticaJsonHandler.java
+++ b/server/src/main/java/org/apache/calcite/avatica/server/AvaticaJsonHandler.java
@@ -138,6 +138,9 @@ public class AvaticaJsonHandler extends AbstractAvaticaHandler {
         } catch (RemoteUserDisallowedException e) {
           LOG.debug("Remote user is not authorized", e);
           jsonResponse = jsonHandler.unauthorizedErrorResponse(e);
+        } catch (BadRequestException e) {
+          LOG.debug("Bad request exception", e);
+          jsonResponse = jsonHandler.badRequestErrorResponse(e);
         } catch (Exception e) {
           LOG.debug("Error invoking request from {}", baseRequest.getRemoteAddr(), e);
           jsonResponse = jsonHandler.convertToErrorResponse(e);

--- a/server/src/main/java/org/apache/calcite/avatica/server/AvaticaProtobufHandler.java
+++ b/server/src/main/java/org/apache/calcite/avatica/server/AvaticaProtobufHandler.java
@@ -139,6 +139,9 @@ public class AvaticaProtobufHandler extends AbstractAvaticaHandler {
       } catch (RemoteUserDisallowedException e) {
         LOG.debug("Remote user is not authorized", e);
         handlerResponse = pbHandler.unauthorizedErrorResponse(e);
+      } catch (BadRequestException e) {
+        LOG.debug("Bad request exception", e);
+        handlerResponse = pbHandler.badRequestErrorResponse(e);
       } catch (Exception e) {
         LOG.debug("Error invoking request from {}", baseRequest.getRemoteAddr(), e);
         // Catch at the highest level of exceptions

--- a/server/src/main/java/org/apache/calcite/avatica/server/BadRequestException.java
+++ b/server/src/main/java/org/apache/calcite/avatica/server/BadRequestException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.server;
+
+/**
+ * An exception thrown when encountering a malformed request.
+ */
+public class BadRequestException extends Exception {
+  private static final long serialVersionUID = 1L;
+
+  public BadRequestException(String message) {
+    super(message);
+  }
+
+  public BadRequestException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}
+
+// End BadRequestException.java


### PR DESCRIPTION
The createErrorResponse function in AstractHandler.java [here](https://github.com/apache/calcite-avatica/blob/1f0f0c1c56b35c4524564a126f1db525437a130b/core/src/main/java/org/apache/calcite/avatica/remote/AbstractHandler.java#L126) doesn't include HTTP_BAD_REQUEST.