### PR TITLE
[CALCITE-5373] Upgrade bouncycastle to 1.70

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,7 @@ checkstyle.version=10.3.2
 spotbugs.version=3.1.11
 
 asm.version=7.1
-bouncycastle.version=1.60
+bouncycastle.version=1.70
 dropwizard-metrics.version=4.0.5
 # We support Guava versions as old as 14.0.1 (the version used by Hive)
 # but prefer more recent versions.


### PR DESCRIPTION
The PR to upgrade bouncycastle version to 1.70 (latest available)