### PR TITLE
[CALCITE-2989] Use ISO calendar system when accessing Date/Time/Timestamp from a number

### DIFF
--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
@@ -1088,9 +1088,7 @@ public class AvaticaResultSetConversionsTest {
     }
 
     @Override public void testGetTime(ResultSet resultSet, Calendar calendar) throws SQLException {
-      // how come both are different? DST...
-      //assertEquals(new Time(1476130718123L), g.getTime(label, calendar));
-      assertEquals(new Time(73118123L), g.getTime(resultSet, calendar));
+      assertEquals(new Time(1476130718123L), g.getTime(resultSet, calendar));
     }
 
     @Override public void testGetTimestamp(ResultSet resultSet, Calendar calendar)

--- a/core/src/test/java/org/apache/calcite/avatica/remote/TypedValueTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/remote/TypedValueTest.java
@@ -32,10 +32,15 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.sql.Array;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -143,22 +148,50 @@ public class TypedValueTest {
   @Test public void testSqlDate() {
     // days since epoch
     serializeAndEqualityCheck(TypedValue.ofLocal(Rep.JAVA_SQL_DATE, 25));
+
+    // From JDBC to local
+    final Calendar calendar = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
+    final TypedValue value =
+        TypedValue.ofJdbc(Rep.JAVA_SQL_DATE, Date.valueOf("1500-04-30"), calendar);
+    assertThat(value.value, is(-171545));
   }
 
   @Test public void testUtilDate() {
-    serializeAndEqualityCheck(
-        TypedValue.ofLocal(Rep.JAVA_UTIL_DATE, System.currentTimeMillis()));
+    final long time = System.currentTimeMillis();
+    serializeAndEqualityCheck(TypedValue.ofLocal(Rep.JAVA_UTIL_DATE, time));
+
+    // From JDBC to local
+    final Calendar calendar = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
+    final TypedValue value = TypedValue.ofJdbc(
+        Rep.JAVA_UTIL_DATE,
+        new Timestamp(time - calendar.getTimeZone().getOffset(time)),
+        calendar);
+    assertThat(value.value, is(time));
   }
 
   @Test public void testSqlTime() {
     // millis since epoch
     serializeAndEqualityCheck(
         TypedValue.ofLocal(Rep.JAVA_SQL_TIME, 42 * 1024 * 1024));
+
+    // From JDBC to local
+    final Calendar calendar = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
+    final TypedValue value =
+        TypedValue.ofJdbc(Rep.JAVA_SQL_TIME, Time.valueOf("00:00:00"), calendar);
+    assertThat(value.value, is(0));
   }
 
   @Test public void testSqlTimestamp() {
     serializeAndEqualityCheck(
         TypedValue.ofLocal(Rep.JAVA_SQL_TIMESTAMP, 42L * 1024 * 1024 * 1024));
+
+    // From JDBC to local
+    final Calendar calendar = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
+    final TypedValue value = TypedValue.ofJdbc(
+        Rep.JAVA_SQL_TIMESTAMP,
+        Timestamp.valueOf("1500-04-30 15:28:27.356"),
+        calendar);
+    assertThat(value.value, is(-14821432292644L));
   }
 
   @Test public void testLegacyDecimalParsing() {

--- a/core/src/test/java/org/apache/calcite/avatica/util/DateAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/DateAccessorTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.sql.SQLException;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test conversions from SQL {@link java.sql.Date} to JDBC types in
+ * {@link AbstractCursor.DateAccessor}.
+ */
+public class DateAccessorTest {
+
+  private static final Calendar UTC =
+      Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.ROOT);
+
+  private Cursor.Accessor instance;
+  private Calendar localCalendar;
+  private Date value;
+
+  /**
+   * Setup test environment by creating a {@link AbstractCursor.DateAccessor} that reads from the
+   * instance variable {@code value}.
+   */
+  @Before public void before() {
+    final AbstractCursor.Getter getter = new LocalGetter();
+    localCalendar = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
+    instance = new AbstractCursor.DateAccessor(getter, localCalendar);
+  }
+
+  /**
+   * Test {@code getDate()} returns the same value as the input date.
+   */
+  @Test public void testDate() throws SQLException {
+    value = new Date(0L);
+    assertThat(instance.getDate(null), is(value));
+
+    value = Date.valueOf("1970-01-01");
+    assertThat(instance.getDate(UTC), is(value));
+
+    value = Date.valueOf("1500-04-30");
+    assertThat(instance.getDate(UTC), is(value));
+  }
+
+  /**
+   * Test {@code getDate()} handles time zone conversions relative to the local calendar and not
+   * UTC.
+   */
+  @Test public void testDateWithCalendar() throws SQLException {
+    value = new Date(0L);
+
+    final TimeZone minusFiveZone = TimeZone.getTimeZone("GMT-5:00");
+    final Calendar minusFiveCal = Calendar.getInstance(minusFiveZone, Locale.ROOT);
+    assertThat(instance.getDate(minusFiveCal).getTime(),
+        is(5 * DateTimeUtils.MILLIS_PER_HOUR));
+
+    final TimeZone plusFiveZone = TimeZone.getTimeZone("GMT+5:00");
+    final Calendar plusFiveCal = Calendar.getInstance(plusFiveZone, Locale.ROOT);
+    assertThat(instance.getDate(plusFiveCal).getTime(),
+        is(-5 * DateTimeUtils.MILLIS_PER_HOUR));
+  }
+
+  /**
+   * Test {@code getString()} supports date range 0001-01-01 to 9999-12-31 required by ANSI SQL.
+   *
+   * <p>This test only uses the UTC time zone because some time zones don't have a January 1st
+   * 12:00am for every year.
+   */
+  @Test public void testStringWithAnsiDateRange() throws SQLException {
+    localCalendar.setTimeZone(UTC.getTimeZone());
+
+    final Calendar utcCal = (Calendar) UTC.clone();
+    utcCal.set(1, Calendar.JANUARY, 1, 0, 0, 0);
+    utcCal.set(Calendar.MILLISECOND, 0);
+
+    for (int i = 2; i <= 9999; ++i) {
+      utcCal.set(Calendar.YEAR, i);
+      value = new Date(utcCal.getTimeInMillis());
+      assertThat(instance.getString(),
+          is(String.format(Locale.ROOT, "%04d-01-01", i)));
+    }
+  }
+
+  /**
+   * Test {@code getString()} returns the same value as the input date.
+   */
+  @Test public void testStringWithLocalTimeZone() throws SQLException {
+    value = Date.valueOf("1970-01-01");
+    assertThat(instance.getString(), is("1970-01-01"));
+
+    value = Date.valueOf("1500-04-30");
+    assertThat(instance.getString(), is("1500-04-30"));
+  }
+
+  /**
+   * Test {@code getString()} returns dates relative to the local calendar.
+   */
+  @Test public void testStringWithUtc() throws SQLException {
+    localCalendar.setTimeZone(UTC.getTimeZone());
+
+    value = new Date(0L);
+    assertThat(instance.getString(), is("1970-01-01"));
+
+    value = new Date(-14820624000000L /* 1500-04-30 */);
+    assertThat(instance.getString(), is("1500-04-30"));
+  }
+
+  /**
+   * Test {@code getLong()} returns the same value as the input date.
+   */
+  @Test public void testLong() throws SQLException {
+    value = new Date(0L);
+    assertThat(instance.getLong(), is(0L));
+
+    value = Date.valueOf("1500-04-30");
+    final Date longDate = new Date(instance.getLong() * DateTimeUtils.MILLIS_PER_DAY);
+    assertThat(longDate.toString(), is("1500-04-30"));
+  }
+
+  /**
+   * Returns the value from the test instance to the accessor.
+   */
+  private class LocalGetter implements AbstractCursor.Getter {
+    @Override public Object getObject() {
+      return value;
+    }
+
+    @Override public boolean wasNull() {
+      return value == null;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/calcite/avatica/util/DateFromNumberAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/DateFromNumberAccessorTest.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.SimpleTimeZone;
+import java.util.TimeZone;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test conversions from SQL DATE as the number of days since 1970-01-01 to JDBC types in
+ * {@link AbstractCursor.DateFromNumberAccessor}.
+ */
+public class DateFromNumberAccessorTest {
+
+  private Cursor.Accessor instance;
+  private Calendar localCalendar;
+  private Object value;
+
+  /**
+   * Setup test environment by creating a {@link AbstractCursor.DateFromNumberAccessor} that reads
+   * from the instance variable {@code value}.
+   */
+  @Before public void before() {
+    final AbstractCursor.Getter getter = new LocalGetter();
+    localCalendar = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
+    instance = new AbstractCursor.DateFromNumberAccessor(getter,
+        localCalendar);
+  }
+
+  /**
+   * Test {@code getDate()} returns the same value as the input date for the local calendar.
+   */
+  @Test public void testDateWithLocalTimeZone() throws SQLException {
+    value = 0;
+    assertThat(instance.getDate(localCalendar), is(Date.valueOf("1970-01-01")));
+
+    value = DateTimeUtils.dateStringToUnixDate("1500-04-30");
+    assertThat(instance.getDate(localCalendar), is(Date.valueOf("1500-04-30")));
+  }
+
+  /**
+   * Test {@code getDate()} shifts between the standard Gregorian calendar and the proleptic
+   * Gregorian calendar.
+   */
+  @Test public void testDateWithGregorianShift() throws SQLException {
+    value = DateTimeUtils.dateStringToUnixDate("1582-10-04");
+    assertThat(instance.getDate(localCalendar), is(Date.valueOf("1582-10-04")));
+
+    value = DateTimeUtils.dateStringToUnixDate("1582-10-05");
+    assertThat(instance.getDate(localCalendar), is(Date.valueOf("1582-10-15")));
+
+    value = DateTimeUtils.dateStringToUnixDate("1582-10-15");
+    assertThat(instance.getDate(localCalendar), is(Date.valueOf("1582-10-15")));
+  }
+
+  /**
+   * Test {@code getDate()} supports date range 0001-01-01 to 9999-12-31 required by ANSI SQL.
+   */
+  @Test public void testDateWithAnsiDateRange() throws SQLException {
+    for (int i = 1; i <= 9999; ++i) {
+      final String str = String.format(Locale.ROOT, "%04d-01-01", i);
+      value = DateTimeUtils.dateStringToUnixDate(str);
+      assertThat(instance.getDate(localCalendar), is(Date.valueOf(str)));
+    }
+  }
+
+  /**
+   * Test {@code getDate()} handles time zone conversions relative to the local calendar and not
+   * UTC.
+   */
+  @Test public void testDateWithCalendar() throws SQLException {
+    final int offset = localCalendar.getTimeZone().getOffset(0);
+    final TimeZone east = new SimpleTimeZone(
+        offset + (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "EAST");
+    final TimeZone west = new SimpleTimeZone(
+        offset - (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "WEST");
+
+    value = 0;
+    assertThat(instance.getDate(Calendar.getInstance(east, Locale.ROOT)),
+        is(Timestamp.valueOf("1969-12-31 23:00:00")));
+    assertThat(instance.getDate(Calendar.getInstance(west, Locale.ROOT)),
+        is(Timestamp.valueOf("1970-01-01 01:00:00")));
+  }
+
+  /**
+   * Test no time zone conversion occurs if the given calendar is {@code null}.
+   */
+  @Test public void testDateWithNullCalendar() throws SQLException {
+    value = 0;
+    assertThat(instance.getDate(null).getTime(),
+        is(0L));
+  }
+
+  /**
+   * Test {@code getDate()} when the local calendar is UTC, which may be different from the default
+   * time zone.
+   */
+  @Test public void testDateWithUtcLocalCalendar() throws SQLException {
+    localCalendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+    value = 0;
+    assertThat(instance.getDate(localCalendar).getTime(), is(0L));
+
+    // Dates before the Gregorian cutoff should be returned using the standard Gregorian calendar
+    // that's used by java.sql.Date and java.util.Calendar
+    value = DateTimeUtils.dateStringToUnixDate("1500-04-30");
+    assertThat(instance.getDate(localCalendar).getTime(), is(-14820624000000L /* 1500-04-30 */));
+  }
+
+  /**
+   * Test {@code getString()} returns the same value as the input date.
+   */
+  @Test public void testString() throws SQLException {
+    value = 0;
+    assertThat(instance.getString(), is("1970-01-01"));
+
+    value = DateTimeUtils.dateStringToUnixDate("1500-04-30");
+    assertThat(instance.getString(), is("1500-04-30"));
+  }
+
+  /**
+   * Test {@code getString()} shifts between the standard Gregorian calendar and the proleptic
+   * Gregorian calendar.
+   */
+  @Test public void testStringWithGregorianShift() throws SQLException {
+    for (int i = 4; i <= 15; ++i) {
+      final String str = String.format(Locale.ROOT, "1582-10-%02d", i);
+      value = DateTimeUtils.dateStringToUnixDate(str);
+      assertThat(instance.getString(), is(str));
+    }
+  }
+
+  /**
+   * Test {@code getString()} supports date range 0001-01-01 to 9999-12-31 required by ANSI SQL.
+   */
+  @Test public void testStringWithAnsiDateRange() throws SQLException {
+    for (int i = 1; i <= 9999; ++i) {
+      final String str = String.format(Locale.ROOT, "%04d-01-01", i);
+      value = DateTimeUtils.dateStringToUnixDate(str);
+      assertThat(instance.getString(), is(str));
+    }
+  }
+
+  /**
+   * Test {@code getTimestamp()} returns the same value as the input date.
+   */
+  @Test public void testTimestamp() throws SQLException {
+    value = 0;
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("1970-01-01 00:00:00.0")));
+
+    value = DateTimeUtils.dateStringToUnixDate("1500-04-30");
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("1500-04-30 00:00:00.0")));
+  }
+
+  /**
+   * Test {@code getTimestamp()} shifts between the standard Gregorian calendar and the proleptic
+   * Gregorian calendar.
+   */
+  @Test public void testTimestampWithGregorianShift() throws SQLException {
+    value = DateTimeUtils.dateStringToUnixDate("1582-10-04");
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("1582-10-04 00:00:00.0")));
+
+    value = DateTimeUtils.dateStringToUnixDate("1582-10-05");
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("1582-10-15 00:00:00.0")));
+
+    value = DateTimeUtils.dateStringToUnixDate("1582-10-15");
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("1582-10-15 00:00:00.0")));
+  }
+
+  /**
+   * Test {@code getTimestamp()} supports date range 0001-01-01 to 9999-12-31 required by ANSI SQL.
+   */
+  @Test public void testTimestampWithAnsiDateRange() throws SQLException {
+    for (int i = 1; i <= 9999; ++i) {
+      final String str = String.format(Locale.ROOT, "%04d-01-01", i);
+      value = DateTimeUtils.dateStringToUnixDate(str);
+      assertThat(instance.getTimestamp(localCalendar),
+          is(Timestamp.valueOf(str + " 00:00:00.0")));
+    }
+  }
+
+  /**
+   * Test {@code getTimestamp()} handles time zone conversions relative to the local calendar and
+   * not UTC.
+   */
+  @Test public void testTimestampWithCalendar() throws SQLException {
+    final int offset = localCalendar.getTimeZone().getOffset(0);
+    final TimeZone east = new SimpleTimeZone(
+        offset + (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "EAST");
+    final TimeZone west = new SimpleTimeZone(
+        offset - (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "WEST");
+
+    value = 0;
+    assertThat(instance.getTimestamp(Calendar.getInstance(east, Locale.ROOT)),
+        is(Timestamp.valueOf("1969-12-31 23:00:00.0")));
+    assertThat(instance.getTimestamp(Calendar.getInstance(west, Locale.ROOT)),
+        is(Timestamp.valueOf("1970-01-01 01:00:00.0")));
+  }
+
+  /**
+   * Test no time zone conversion occurs if the given calendar is {@code null}.
+   */
+  @Test public void testTimestampWithNullCalendar() throws SQLException {
+    value = 0;
+    assertThat(instance.getTimestamp(null).getTime(),
+        is(0L));
+  }
+
+  /**
+   * Returns the value from the test instance to the accessor.
+   */
+  private class LocalGetter implements AbstractCursor.Getter {
+    @Override public Object getObject() {
+      return value;
+    }
+
+    @Override public boolean wasNull() {
+      return value == null;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/calcite/avatica/util/TimeAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/TimeAccessorTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.sql.Time;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test conversions from SQL {@link Time} to JDBC types in {@link AbstractCursor.TimeAccessor}.
+ */
+public class TimeAccessorTest {
+
+  private static final Calendar UTC =
+      Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.ROOT);
+
+  private Cursor.Accessor instance;
+  private Calendar localCalendar;
+  private Time value;
+
+  /**
+   * Setup test environment by creating a {@link AbstractCursor.TimeAccessor} that reads from the
+   * instance variable {@code value}.
+   */
+  @Before public void before() {
+    final AbstractCursor.Getter getter = new LocalGetter();
+    localCalendar = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
+    instance = new AbstractCursor.TimeAccessor(getter, localCalendar);
+  }
+
+  /**
+   * Test {@code getTime()} returns the same value as the input time for the local calendar.
+   */
+  @Test public void testTime() throws SQLException {
+    value = new Time(0L);
+    assertThat(instance.getTime(null), is(value));
+
+    value = Time.valueOf("00:00:00");
+    assertThat(instance.getTime(UTC), is(value));
+
+    value = Time.valueOf("23:59:59");
+    assertThat(instance.getTime(UTC), is(value));
+  }
+
+  /**
+   * Test {@code getTime()} handles time zone conversions relative to the local calendar and not
+   * UTC.
+   */
+  @Test public void testTimeWithCalendar() throws SQLException {
+    value = new Time(0L);
+
+    final TimeZone minusFiveZone = TimeZone.getTimeZone("GMT-5:00");
+    final Calendar minusFiveCal = Calendar.getInstance(minusFiveZone, Locale.ROOT);
+    assertThat(instance.getTime(minusFiveCal).getTime(),
+        is(5 * DateTimeUtils.MILLIS_PER_HOUR));
+
+    final TimeZone plusFiveZone = TimeZone.getTimeZone("GMT+5:00");
+    final Calendar plusFiveCal = Calendar.getInstance(plusFiveZone, Locale.ROOT);
+    assertThat(instance.getTime(plusFiveCal).getTime(),
+        is(-5 * DateTimeUtils.MILLIS_PER_HOUR));
+  }
+
+  /**
+   * Test {@code getString()} returns the same value as the input time.
+   */
+  @Test public void testStringWithLocalTimeZone() throws SQLException {
+    value = Time.valueOf("00:00:00");
+    assertThat(instance.getString(), is("00:00:00"));
+
+    value = Time.valueOf("23:59:59");
+    assertThat(instance.getString(), is("23:59:59"));
+  }
+
+  /**
+   * Test {@code getString()} when the local calendar is UTC, which may be different from the
+   * default time zone.
+   */
+  @Test public void testStringWithUtc() throws SQLException {
+    localCalendar.setTimeZone(UTC.getTimeZone());
+
+    value = new Time(0L);
+    assertThat(instance.getString(), is("00:00:00"));
+
+    value = new Time(DateTimeUtils.MILLIS_PER_DAY - 1000);
+    assertThat(instance.getString(), is("23:59:59"));
+  }
+
+  /**
+   * Test {@code getLong()} returns the same value as the input time.
+   */
+  @Test public void testLong() throws SQLException {
+    value = new Time(0L);
+    assertThat(instance.getLong(), is(0L));
+
+    value = Time.valueOf("23:59:59");
+    final Time longTime = new Time(instance.getLong());
+    assertThat(longTime.toString(), is("23:59:59"));
+  }
+
+  /**
+   * Returns the value from the test instance to the accessor.
+   */
+  private class LocalGetter implements AbstractCursor.Getter {
+    @Override public Object getObject() {
+      return value;
+    }
+
+    @Override public boolean wasNull() {
+      return value == null;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/calcite/avatica/util/TimeFromNumberAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/TimeFromNumberAccessorTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.SimpleTimeZone;
+import java.util.TimeZone;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test conversions from SQL TIME as the number of milliseconds since 1970-01-01 00:00:00 to JDBC
+ * types in {@link AbstractCursor.TimeFromNumberAccessor}.
+ */
+public class TimeFromNumberAccessorTest {
+
+  private Cursor.Accessor instance;
+  private Calendar localCalendar;
+  private Object value;
+
+  /**
+   * Setup test environment by creating a {@link AbstractCursor.TimeFromNumberAccessor} that reads
+   * from the instance variable {@code value}.
+   */
+  @Before public void before() {
+    final AbstractCursor.Getter getter = new LocalGetter();
+    localCalendar = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
+    instance = new AbstractCursor.TimeFromNumberAccessor(getter,
+        localCalendar);
+  }
+
+  /**
+   * Test {@code getString()} returns the same value as the input time.
+   */
+  @Test public void testString() throws SQLException {
+    value = 0;
+    assertThat(instance.getString(), is("00:00:00"));
+
+    value = DateTimeUtils.MILLIS_PER_DAY - 1000;
+    assertThat(instance.getString(), is("23:59:59"));
+  }
+
+  /**
+   * Test {@code getTime()} returns the same value as the input time for the local calendar.
+   */
+  @Test public void testTime() throws SQLException {
+    value = 0;
+    assertThat(instance.getTime(localCalendar), is(Time.valueOf("00:00:00")));
+
+    value = DateTimeUtils.MILLIS_PER_DAY - 1000;
+    assertThat(instance.getTime(localCalendar), is(Time.valueOf("23:59:59")));
+  }
+
+  /**
+   * Test {@code getTime()} handles time zone conversions relative to the local calendar and not
+   * UTC.
+   */
+  @Test public void testTimeWithCalendar() throws SQLException {
+    final int offset = localCalendar.getTimeZone().getOffset(0);
+    final TimeZone east = new SimpleTimeZone(
+        offset + (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "EAST");
+    final TimeZone west = new SimpleTimeZone(
+        offset - (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "WEST");
+
+    value = 0;
+    assertThat(instance.getTime(Calendar.getInstance(east, Locale.ROOT)),
+        is(Timestamp.valueOf("1969-12-31 23:00:00")));
+    assertThat(instance.getTime(Calendar.getInstance(west, Locale.ROOT)),
+        is(Timestamp.valueOf("1970-01-01 01:00:00")));
+  }
+
+  /**
+   * Test no time zone conversion occurs if the given calendar is {@code null}.
+   */
+  @Test public void testTimeWithNullCalendar() throws SQLException {
+    value = 0;
+    assertThat(instance.getTime(null).getTime(),
+        is(0L));
+  }
+
+  /**
+   * Test {@code getTimestamp()} returns the same value as the input time.
+   */
+  @Test public void testTimestamp() throws SQLException {
+    value = 0;
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("1970-01-01 00:00:00.0")));
+
+    value = DateTimeUtils.MILLIS_PER_DAY - 1000;
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("1970-01-01 23:59:59.0")));
+  }
+
+  /**
+   * Test {@code getTimestamp()} handles time zone conversions relative to the local calendar and
+   * not UTC.
+   */
+  @Test public void testTimestampWithCalendar() throws SQLException {
+    final int offset = localCalendar.getTimeZone().getOffset(0);
+    final TimeZone east = new SimpleTimeZone(
+        offset + (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "EAST");
+    final TimeZone west = new SimpleTimeZone(
+        offset - (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "WEST");
+
+    value = 0;
+    assertThat(instance.getTimestamp(Calendar.getInstance(east, Locale.ROOT)),
+        is(Timestamp.valueOf("1969-12-31 23:00:00.0")));
+    assertThat(instance.getTimestamp(Calendar.getInstance(west, Locale.ROOT)),
+        is(Timestamp.valueOf("1970-01-01 01:00:00.0")));
+  }
+
+  /**
+   * Test no time zone conversion occurs if the given calendar is {@code null}.
+   */
+  @Test public void testTimestampWithNullCalendar() throws SQLException {
+    value = 0;
+    assertThat(instance.getTimestamp(null).getTime(),
+        is(0L));
+  }
+
+  /**
+   * Returns the value from the test instance to the accessor.
+   */
+  private class LocalGetter implements AbstractCursor.Getter {
+    @Override public Object getObject() {
+      return value;
+    }
+
+    @Override public boolean wasNull() {
+      return value == null;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/calcite/avatica/util/TimestampAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/TimestampAccessorTest.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static org.apache.calcite.avatica.util.DateTimeUtils.*;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test conversions from SQL {@link Timestamp} to JDBC types in
+ * {@link AbstractCursor.TimestampAccessor}.
+ */
+public class TimestampAccessorTest {
+
+  private static final Calendar UTC =
+      Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.ROOT);
+
+  private Cursor.Accessor instance;
+  private Calendar localCalendar;
+  private Timestamp value;
+
+  /**
+   * Setup test environment by creating a {@link AbstractCursor.TimestampAccessor} that reads from
+   * the instance variable {@code value}.
+   */
+  @Before public void before() {
+    final AbstractCursor.Getter getter = new LocalGetter();
+    localCalendar = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
+    instance = new AbstractCursor.TimestampAccessor(getter, localCalendar);
+  }
+
+  /**
+   * Test {@code getTimestamp()} returns the same value as the input timestamp for the local
+   * calendar.
+   */
+  @Test public void testTimestamp() throws SQLException {
+    value = new Timestamp(0L);
+    assertThat(instance.getTimestamp(null), is(value));
+
+    value = Timestamp.valueOf("1970-01-01 00:00:00");
+    assertThat(instance.getTimestamp(UTC), is(value));
+
+    value = Timestamp.valueOf("2014-09-30 15:28:27.356");
+    assertThat(instance.getTimestamp(UTC), is(value));
+
+    value = Timestamp.valueOf("1500-04-30 12:00:00.123");
+    assertThat(instance.getTimestamp(UTC), is(value));
+  }
+
+  /**
+   * Test {@code getTimestamp()} handles time zone conversions relative to the local calendar and
+   * not UTC.
+   */
+  @Test public void testTimestampWithCalendar() throws SQLException {
+    value = new Timestamp(0L);
+
+    final TimeZone minusFiveZone = TimeZone.getTimeZone("GMT-5:00");
+    final Calendar minusFiveCal = Calendar.getInstance(minusFiveZone, Locale.ROOT);
+    assertThat(instance.getTimestamp(minusFiveCal).getTime(),
+        is(5 * MILLIS_PER_HOUR));
+
+    final TimeZone plusFiveZone = TimeZone.getTimeZone("GMT+5:00");
+    final Calendar plusFiveCal = Calendar.getInstance(plusFiveZone, Locale.ROOT);
+    assertThat(instance.getTimestamp(plusFiveCal).getTime(),
+        is(-5 * MILLIS_PER_HOUR));
+  }
+
+  /**
+   * Test {@code getDate()} returns the same value as the input timestamp for the local calendar.
+   */
+  @Test public void testDate() throws SQLException {
+    value = new Timestamp(0L);
+    assertThat(instance.getDate(null), is(new Date(0L)));
+
+    value = Timestamp.valueOf("1970-01-01 00:00:00");
+    assertThat(instance.getDate(UTC), is(Date.valueOf("1970-01-01")));
+
+    value = Timestamp.valueOf("1500-04-30 00:00:00");
+    assertThat(instance.getDate(UTC), is(Date.valueOf("1500-04-30")));
+  }
+
+  /**
+   * Test {@code getDate()} handles time zone conversions relative to the local calendar and not
+   * UTC.
+   */
+  @Test public void testDateWithCalendar() throws SQLException {
+    value = new Timestamp(0L);
+
+    final TimeZone minusFiveZone = TimeZone.getTimeZone("GMT-5:00");
+    final Calendar minusFiveCal = Calendar.getInstance(minusFiveZone, Locale.ROOT);
+    assertThat(instance.getDate(minusFiveCal).getTime(),
+        is(5 * DateTimeUtils.MILLIS_PER_HOUR));
+
+    final TimeZone plusFiveZone = TimeZone.getTimeZone("GMT+5:00");
+    final Calendar plusFiveCal = Calendar.getInstance(plusFiveZone, Locale.ROOT);
+    assertThat(instance.getDate(plusFiveCal).getTime(),
+        is(-5 * DateTimeUtils.MILLIS_PER_HOUR));
+  }
+
+  /**
+   * Test {@code getTime()} returns the same value as the input timestamp for the local calendar.
+   */
+  @Test public void testTime() throws SQLException {
+    value = new Timestamp(0L);
+    assertThat(instance.getTime(null), is(new Time(0L)));
+
+    value = Timestamp.valueOf("1970-01-01 00:00:00");
+    assertThat(instance.getTime(UTC), is(Time.valueOf("00:00:00")));
+
+    value = Timestamp.valueOf("2014-09-30 15:28:27.356");
+    assertThat(instance.getTime(UTC).toString(), is("15:28:27"));
+  }
+
+  /**
+   * Test {@code getTime()} handles time zone conversions relative to the local calendar and not
+   * UTC.
+   */
+  @Test public void testTimeWithCalendar() throws SQLException {
+    value = new Timestamp(0L);
+
+    final TimeZone minusFiveZone = TimeZone.getTimeZone("GMT-5:00");
+    final Calendar minusFiveCal = Calendar.getInstance(minusFiveZone, Locale.ROOT);
+    assertThat(instance.getTime(minusFiveCal).getTime(),
+        is(5 * DateTimeUtils.MILLIS_PER_HOUR));
+
+    final TimeZone plusFiveZone = TimeZone.getTimeZone("GMT+5:00");
+    final Calendar plusFiveCal = Calendar.getInstance(plusFiveZone, Locale.ROOT);
+    assertThat(instance.getTime(plusFiveCal).getTime(),
+        is(-5 * DateTimeUtils.MILLIS_PER_HOUR));
+  }
+
+  /**
+   * Test {@code getString()} returns the same value as the input timestamp.
+   */
+  @Test public void testString() throws SQLException {
+    value = Timestamp.valueOf("1970-01-01 00:00:00");
+    assertThat(instance.getString(), is("1970-01-01 00:00:00"));
+
+    value = Timestamp.valueOf("2014-09-30 15:28:27.356");
+    assertThat(instance.getString(), is("2014-09-30 15:28:27"));
+
+    value = Timestamp.valueOf("1500-04-30 12:00:00.123");
+    assertThat(instance.getString(), is("1500-04-30 12:00:00"));
+  }
+
+  /**
+   * Test {@code getString()} shifts between the standard Gregorian calendar and the proleptic
+   * Gregorian calendar.
+   */
+  @Test public void testStringWithGregorianShift() throws SQLException {
+    value = Timestamp.valueOf("1582-10-04 00:00:00");
+    assertThat(instance.getString(), is("1582-10-04 00:00:00"));
+    value = Timestamp.valueOf("1582-10-05 00:00:00");
+    assertThat(instance.getString(), is("1582-10-15 00:00:00"));
+    value = Timestamp.valueOf("1582-10-15 00:00:00");
+    assertThat(instance.getString(), is("1582-10-15 00:00:00"));
+  }
+
+  /**
+   * Test {@code getString()} returns dates relative to the local calendar.
+   */
+  @Test public void testStringWithUtc() throws SQLException {
+    localCalendar.setTimeZone(UTC.getTimeZone());
+
+    value = new Timestamp(0L);
+    assertThat(instance.getString(), is("1970-01-01 00:00:00"));
+
+    value = new Timestamp(1412090907356L /* 2014-09-30 15:28:27.356 UTC */);
+    assertThat(instance.getString(), is("2014-09-30 15:28:27"));
+
+    value = new Timestamp(-14820580799877L /* 1500-04-30 12:00:00.123 */);
+    assertThat(instance.getString(), is("1500-04-30 12:00:00"));
+  }
+
+  /**
+   * Test {@code getString()} supports date range 0001-01-01 to 9999-12-31 required by ANSI SQL.
+   *
+   * <p>This test only uses the UTC time zone because some time zones don't have a January 1st
+   * 12:00am for every year.
+   */
+  @Test public void testStringWithAnsiDateRange() throws SQLException {
+    localCalendar.setTimeZone(UTC.getTimeZone());
+
+    final Calendar utcCal = (Calendar) UTC.clone();
+    utcCal.set(1, Calendar.JANUARY, 1, 0, 0, 0);
+    utcCal.set(Calendar.MILLISECOND, 0);
+
+    for (int i = 2; i <= 9999; ++i) {
+      utcCal.set(Calendar.YEAR, i);
+      value = new Timestamp(utcCal.getTimeInMillis());
+      assertThat(instance.getString(),
+          is(String.format(Locale.ROOT, "%04d-01-01 00:00:00", i)));
+    }
+  }
+
+  /**
+   * Test {@code getLong()} returns the same value as the input timestamp.
+   */
+  @Test public void testLong() throws SQLException {
+    value = new Timestamp(0L);
+    assertThat(instance.getLong(), is(0L));
+
+    value = Timestamp.valueOf("2014-09-30 15:28:27.356");
+    assertThat(instance.getLong(), is(value.getTime()));
+
+    value = Timestamp.valueOf("1500-04-30 00:00:00");
+    assertThat(instance.getLong(), is(value.getTime()));
+  }
+
+  /**
+   * Returns the value from the test instance to the accessor.
+   */
+  private class LocalGetter implements AbstractCursor.Getter {
+    @Override public Object getObject() {
+      return value;
+    }
+
+    @Override public boolean wasNull() {
+      return value == null;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/calcite/avatica/util/TimestampFromNumberAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/TimestampFromNumberAccessorTest.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.SimpleTimeZone;
+import java.util.TimeZone;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test conversions from SQL TIMESTAMP as the number of milliseconds since 1970-01-01 00:00:00 to
+ * JDBC types in {@link AbstractCursor.TimestampFromNumberAccessor}.
+ */
+public class TimestampFromNumberAccessorTest {
+
+  private Cursor.Accessor instance;
+  private Calendar localCalendar;
+  private Object value;
+
+  /**
+   * Setup test environment by creating a {@link AbstractCursor.TimestampFromNumberAccessor} that
+   * reads from the instance variable {@code value}.
+   */
+  @Before public void before() {
+    final AbstractCursor.Getter getter = new LocalGetter();
+    localCalendar = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
+    instance = new AbstractCursor.TimestampFromNumberAccessor(getter,
+        localCalendar);
+  }
+
+  /**
+   * Test {@code getDate()} returns the same value as the input timestamp for the local calendar.
+   */
+  @Test public void testDate() throws SQLException {
+    value = 0L;
+    assertThat(instance.getDate(localCalendar),
+        is(Date.valueOf("1970-01-01")));
+
+    value = DateTimeUtils.timestampStringToUnixDate("1500-04-30 12:00:00");
+    assertThat(instance.getDate(localCalendar),
+        is(Timestamp.valueOf("1500-04-30 12:00:00")));
+  }
+
+  /**
+   * Test {@code getDate()} handles time zone conversions relative to the local calendar and not
+   * UTC.
+   */
+  @Test public void testDateWithCalendar() throws SQLException {
+    value = 0L;
+
+    final TimeZone minusFiveZone = TimeZone.getTimeZone("GMT-5:00");
+    final Calendar minusFiveCal = Calendar.getInstance(minusFiveZone, Locale.ROOT);
+    assertThat(instance.getDate(minusFiveCal).getTime(),
+        is(5 * DateTimeUtils.MILLIS_PER_HOUR));
+
+    final TimeZone plusFiveZone = TimeZone.getTimeZone("GMT+5:00");
+    final Calendar plusFiveCal = Calendar.getInstance(plusFiveZone, Locale.ROOT);
+    assertThat(instance.getDate(plusFiveCal).getTime(),
+        is(-5 * DateTimeUtils.MILLIS_PER_HOUR));
+  }
+
+  /**
+   * Test no time zone conversion occurs if the given calendar is {@code null}.
+   */
+  @Test public void testDateWithNullCalendar() throws SQLException {
+    value = 0;
+    assertThat(instance.getDate(null), is(new Date(0L)));
+  }
+
+  /**
+   * Test {@code getString()} returns the same value as the input timestamp.
+   */
+  @Test public void testString() throws SQLException {
+    value = 0;
+    assertThat(instance.getString(), is("1970-01-01 00:00:00"));
+
+    value = DateTimeUtils.timestampStringToUnixDate("2014-09-30 15:28:27.356");
+    assertThat(instance.getString(), is("2014-09-30 15:28:27"));
+
+    value = DateTimeUtils.timestampStringToUnixDate("1500-04-30 12:00:00.123");
+    assertThat(instance.getString(), is("1500-04-30 12:00:00"));
+  }
+
+  /**
+   * Test {@code getString()} shifts between the standard Gregorian calendar and the proleptic
+   * Gregorian calendar.
+   */
+  @Test public void testStringWithGregorianShift() throws SQLException {
+    for (int i = 4; i <= 15; ++i) {
+      final String str = String.format(Locale.ROOT, "1582-10-%02d 00:00:00", i);
+      value = DateTimeUtils.timestampStringToUnixDate(str);
+      assertThat(instance.getString(), is(str));
+    }
+  }
+
+  /**
+   * Test {@code getString()} returns timestamps relative to the local calendar.
+   */
+  @Test public void testStringWithUtc() throws SQLException {
+    localCalendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+    value = 0L;
+    assertThat(instance.getString(), is("1970-01-01 00:00:00"));
+
+    value = 1412090907356L;  // 2014-09-30 15:28:27.356 UTC
+    assertThat(instance.getString(), is("2014-09-30 15:28:27"));
+
+    value = -14821444799877L;  // 1500-04-30 12:00:00.123
+    assertThat(instance.getString(), is("1500-04-30 12:00:00"));
+  }
+
+  /**
+   * Test {@code getString()} supports date range 0001-01-01 to 9999-12-31 required by ANSI SQL.
+   *
+   * <p>This test only uses the UTC time zone because some time zones don't have a January 1st
+   * 12:00am for every year.
+   */
+  @Test public void testStringWithAnsiDateRange() throws SQLException {
+    for (int i = 1; i <= 9999; ++i) {
+      final String str = String.format(Locale.ROOT, "%04d-01-01 00:00:00", i);
+      value = DateTimeUtils.timestampStringToUnixDate(str);
+      assertThat(instance.getString(), is(str));
+    }
+  }
+
+  /**
+   * Test {@code getTime()} returns the same value as the input timestamp for the local calendar.
+   */
+  @Test public void testTime() throws SQLException {
+    value = 0L;
+    assertThat(instance.getTime(localCalendar).toString(), is("00:00:00"));
+
+    value = DateTimeUtils.timestampStringToUnixDate("2014-09-30 15:28:27.356");
+    assertThat(instance.getTime(localCalendar).toString(), is("15:28:27"));
+  }
+
+  /**
+   * Test {@code getTime()} handles time zone conversions relative to the local calendar and not
+   * UTC.
+   */
+  @Test public void testTimeWithCalendar() throws SQLException {
+    final int offset = localCalendar.getTimeZone().getOffset(0);
+    final TimeZone east = new SimpleTimeZone(
+        offset + (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "EAST");
+    final TimeZone west = new SimpleTimeZone(
+        offset - (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "WEST");
+
+    value = 0;
+    assertThat(instance.getTime(Calendar.getInstance(east, Locale.ROOT)),
+        is(Timestamp.valueOf("1969-12-31 23:00:00")));
+    assertThat(instance.getTime(Calendar.getInstance(west, Locale.ROOT)),
+        is(Timestamp.valueOf("1970-01-01 01:00:00")));
+  }
+
+  /**
+   * Test no time zone conversion occurs if the given calendar is {@code null}.
+   */
+  @Test public void testTimeWithNullCalendar() throws SQLException {
+    value = 0;
+    assertThat(instance.getTime(null), is(new Time(0L)));
+  }
+
+  /**
+   * Test {@code getTimestamp()} returns the same value as the input timestamp for the local
+   * calendar.
+   */
+  @Test public void testTimestamp() throws SQLException {
+    value = 0L;
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("1970-01-01 00:00:00.0")));
+
+    value = DateTimeUtils.timestampStringToUnixDate("2014-09-30 15:28:27.356");
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("2014-09-30 15:28:27.356")));
+
+    value = DateTimeUtils.timestampStringToUnixDate("1500-04-30 12:00:00");
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("1500-04-30 12:00:00.0")));
+  }
+
+  /**
+   * Test {@code getTimestamp()} shifts between the standard Gregorian calendar and the proleptic
+   * Gregorian calendar.
+   */
+  @Test public void testTimestampWithGregorianShift() throws SQLException {
+    value = DateTimeUtils.timestampStringToUnixDate("1582-10-04 00:00:00");
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("1582-10-04 00:00:00.0")));
+
+    value = DateTimeUtils.timestampStringToUnixDate("1582-10-05 00:00:00");
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("1582-10-15 00:00:00.0")));
+
+    value = DateTimeUtils.timestampStringToUnixDate("1582-10-15 00:00:00");
+    assertThat(instance.getTimestamp(localCalendar),
+        is(Timestamp.valueOf("1582-10-15 00:00:00.0")));
+  }
+
+  /**
+   * Test {@code getTimestamp()} supports date range 0001-01-01 to 9999-12-31 required by ANSI SQL.
+   */
+  @Test public void testTimestampWithAnsiDateRange() throws SQLException {
+    for (int i = 1; i <= 9999; ++i) {
+      final String str = String.format(Locale.ROOT, "%04d-01-01 00:00:00.0", i);
+      value = DateTimeUtils.timestampStringToUnixDate(str);
+      assertThat(instance.getTimestamp(localCalendar),
+          is(Timestamp.valueOf(str)));
+    }
+  }
+
+  /**
+   * Test {@code getTimestamp()} handles time zone conversions relative to the local calendar and
+   * not UTC.
+   */
+  @Test public void testTimestampWithCalendar() throws SQLException {
+    final int offset = localCalendar.getTimeZone().getOffset(0);
+    final TimeZone east = new SimpleTimeZone(
+        offset + (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "EAST");
+    final TimeZone west = new SimpleTimeZone(
+        offset - (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "WEST");
+
+    value = 0;
+    assertThat(instance.getTimestamp(Calendar.getInstance(east, Locale.ROOT)),
+        is(Timestamp.valueOf("1969-12-31 23:00:00.0")));
+    assertThat(instance.getTimestamp(Calendar.getInstance(west, Locale.ROOT)),
+        is(Timestamp.valueOf("1970-01-01 01:00:00.0")));
+  }
+
+  /**
+   * Test no time zone conversion occurs if the given calendar is {@code null}.
+   */
+  @Test public void testTimestampWithNullCalendar() throws SQLException {
+    value = 0;
+    assertThat(instance.getTimestamp(null).getTime(),
+        is(0L));
+  }
+
+  /**
+   * Returns the value from the test instance to the accessor.
+   */
+  private class LocalGetter implements AbstractCursor.Getter {
+    @Override public Object getObject() {
+      return value;
+    }
+
+    @Override public boolean wasNull() {
+      return value == null;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/calcite/avatica/util/TimestampFromUtilDateAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/TimestampFromUtilDateAccessorTest.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.SimpleTimeZone;
+import java.util.TimeZone;
+
+import static org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_HOUR;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test conversions from SQL {@link java.util.Date} to JDBC types in
+ * {@link AbstractCursor.TimestampFromUtilDateAccessor}.
+ */
+public class TimestampFromUtilDateAccessorTest {
+
+  private static final Calendar UTC =
+      Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.ROOT);
+
+  private Cursor.Accessor instance;
+  private Calendar localCalendar;
+  private Date value;
+
+  /**
+   * Setup test environment by creating a {@link AbstractCursor.TimestampFromUtilDateAccessor} that
+   * reads from the instance variable {@code value}.
+   */
+  @Before public void before() {
+    final AbstractCursor.Getter getter = new LocalGetter();
+    localCalendar = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
+    instance = new AbstractCursor.TimestampFromUtilDateAccessor(getter, localCalendar);
+  }
+
+  /**
+   * Test {@code getTimestamp()} returns the same value as the input timestamp for the local
+   * calendar.
+   */
+  @Test public void testTimestamp() throws SQLException {
+    value = new Timestamp(0L);
+    assertThat(instance.getTimestamp(null), is(value));
+
+    value = Timestamp.valueOf("1970-01-01 00:00:00");
+    assertThat(instance.getTimestamp(UTC), is(value));
+
+    value = Timestamp.valueOf("2014-09-30 15:28:27.356");
+    assertThat(instance.getTimestamp(UTC), is(value));
+
+    value = Timestamp.valueOf("1500-04-30 12:00:00.123");
+    assertThat(instance.getTimestamp(UTC), is(value));
+  }
+
+  /**
+   * Test {@code getTimestamp()} handles time zone conversions relative to the local calendar and
+   * not UTC.
+   */
+  @Test public void testTimestampWithCalendar() throws SQLException {
+    value = new Timestamp(0L);
+
+    final TimeZone minusFiveZone = TimeZone.getTimeZone("GMT-5:00");
+    final Calendar minusFiveCal = Calendar.getInstance(minusFiveZone, Locale.ROOT);
+    assertThat(instance.getTimestamp(minusFiveCal).getTime(),
+        is(5 * MILLIS_PER_HOUR));
+
+    final TimeZone plusFiveZone = TimeZone.getTimeZone("GMT+5:00");
+    final Calendar plusFiveCal = Calendar.getInstance(plusFiveZone, Locale.ROOT);
+    assertThat(instance.getTimestamp(plusFiveCal).getTime(),
+        is(-5 * MILLIS_PER_HOUR));
+  }
+
+  /**
+   * Test {@code getDate()} returns the same value as the input timestamp for the local calendar.
+   */
+  @Test public void testDate() throws SQLException {
+    value = new java.sql.Date(0L);
+    assertThat(instance.getDate(null), is(value));
+
+    value = java.sql.Date.valueOf("1970-01-01");
+    assertThat(instance.getDate(UTC), is(value));
+
+    value = java.sql.Date.valueOf("1500-04-30");
+    assertThat(instance.getDate(UTC), is(value));
+  }
+
+  /**
+   * Test {@code getDate()} handles time zone conversions relative to the local calendar and not
+   * UTC.
+   */
+  @Test public void testDateWithCalendar() throws SQLException {
+    value = new java.sql.Date(0L);
+
+    final TimeZone minusFiveZone = TimeZone.getTimeZone("GMT-5:00");
+    final Calendar minusFiveCal = Calendar.getInstance(minusFiveZone, Locale.ROOT);
+    assertThat(instance.getDate(minusFiveCal).getTime(),
+        is(5 * DateTimeUtils.MILLIS_PER_HOUR));
+
+    final TimeZone plusFiveZone = TimeZone.getTimeZone("GMT+5:00");
+    final Calendar plusFiveCal = Calendar.getInstance(plusFiveZone, Locale.ROOT);
+    assertThat(instance.getDate(plusFiveCal).getTime(),
+        is(-5 * DateTimeUtils.MILLIS_PER_HOUR));
+  }
+
+  /**
+   * Test {@code getTime()} returns the same value as the input timestamp for the local calendar.
+   */
+  @Test public void testTime() throws SQLException {
+    value = new Time(0L);
+    assertThat(instance.getTime(null), is(value));
+
+    value = Time.valueOf("00:00:00");
+    assertThat(instance.getTime(UTC), is(value));
+
+    value = Time.valueOf("23:59:59");
+    assertThat(instance.getTime(UTC).toString(), is("23:59:59"));
+  }
+
+  /**
+   * Test {@code getTime()} handles time zone conversions relative to the local calendar and not
+   * UTC.
+   */
+  @Test public void testTimeWithCalendar() throws SQLException {
+    final int offset = localCalendar.getTimeZone().getOffset(0);
+    final TimeZone east = new SimpleTimeZone(
+        offset + (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "EAST");
+    final TimeZone west = new SimpleTimeZone(
+        offset - (int) DateTimeUtils.MILLIS_PER_HOUR,
+        "WEST");
+
+    value = new Time(0L);
+    assertThat(instance.getTime(Calendar.getInstance(east, Locale.ROOT)),
+        is(Timestamp.valueOf("1969-12-31 23:00:00")));
+    assertThat(instance.getTime(Calendar.getInstance(west, Locale.ROOT)),
+        is(Timestamp.valueOf("1970-01-01 01:00:00")));
+  }
+
+  /**
+   * Test {@code getString()} returns the same value as the input timestamp.
+   */
+  @Test public void testStringWithLocalTimeZone() throws SQLException {
+    value = Timestamp.valueOf("1970-01-01 00:00:00");
+    assertThat(instance.getString(), is("1970-01-01 00:00:00"));
+
+    value = Timestamp.valueOf("2014-09-30 15:28:27.356");
+    assertThat(instance.getString(), is("2014-09-30 15:28:27"));
+
+    value = Timestamp.valueOf("1500-04-30 12:00:00.123");
+    assertThat(instance.getString(), is("1500-04-30 12:00:00"));
+  }
+
+  /**
+   * Test {@code getString()} shifts between the standard Gregorian calendar and the proleptic
+   * Gregorian calendar.
+   */
+  @Test public void testStringWithGregorianShift() throws SQLException {
+    value = Timestamp.valueOf("1582-10-04 00:00:00");
+    assertThat(instance.getString(), is("1582-10-04 00:00:00"));
+    value = Timestamp.valueOf("1582-10-05 00:00:00");
+    assertThat(instance.getString(), is("1582-10-15 00:00:00"));
+    value = Timestamp.valueOf("1582-10-15 00:00:00");
+    assertThat(instance.getString(), is("1582-10-15 00:00:00"));
+  }
+
+  /**
+   * Test {@code getString()} returns timestamps relative to the local calendar.
+   */
+  @Test public void testStringWithUtc() throws SQLException {
+    localCalendar.setTimeZone(UTC.getTimeZone());
+
+    value = new Timestamp(0L);
+    assertThat(instance.getString(), is("1970-01-01 00:00:00"));
+
+    value = new Timestamp(1412090907356L /* 2014-09-30 15:28:27.356 UTC */);
+    assertThat(instance.getString(), is("2014-09-30 15:28:27"));
+
+    value = new Timestamp(-14820580799877L /* 1500-04-30 12:00:00.123 UTC */);
+    assertThat(instance.getString(), is("1500-04-30 12:00:00"));
+  }
+
+  /**
+   * Test {@code getString()} supports date range 0001-01-01 to 9999-12-31 required by ANSI SQL.
+   *
+   * <p>This test only uses the UTC time zone because some time zones don't have a January 1st
+   * 12:00am for every year.
+   */
+  @Test public void testStringWithAnsiDateRange() throws SQLException {
+    localCalendar.setTimeZone(UTC.getTimeZone());
+
+    final Calendar utcCal = (Calendar) UTC.clone();
+    utcCal.set(1, Calendar.JANUARY, 1, 0, 0, 0);
+    utcCal.set(Calendar.MILLISECOND, 0);
+
+    for (int i = 2; i <= 9999; ++i) {
+      utcCal.set(Calendar.YEAR, i);
+      value = new Timestamp(utcCal.getTimeInMillis());
+      assertThat(instance.getString(),
+          is(String.format(Locale.ROOT, "%04d-01-01 00:00:00", i)));
+    }
+  }
+
+  /**
+   * Test {@code getLong()} returns the same value as the input timestamp.
+   */
+  @Test public void testLong() throws SQLException {
+    value = new Timestamp(0L);
+    assertThat(instance.getLong(), is((long) -localCalendar.getTimeZone().getOffset(0L)));
+
+    value = Timestamp.valueOf("2014-09-30 15:28:27.356");
+    assertThat(instance.getLong(),
+        is(value.getTime() - localCalendar.getTimeZone().getOffset(value.getTime())));
+
+    value = Timestamp.valueOf("1500-04-30 00:00:00");
+    assertThat(instance.getLong(),
+        is(value.getTime() - localCalendar.getTimeZone().getOffset(value.getTime())));
+  }
+
+  /**
+   * Returns the value from the test instance to the accessor.
+   */
+  private class LocalGetter implements AbstractCursor.Getter {
+    @Override public Object getObject() {
+      return value;
+    }
+
+    @Override public boolean wasNull() {
+      return value == null;
+    }
+  }
+}


### PR DESCRIPTION
This changes the unix timestamp to Date/Time/Timestamp conversion in `AbstractCursor` to convert between the ISO calendar system and the standard Gregorian calendar. This ensures that unix timestamps produced by `DateTimeUtils` are correctly converted to `java.sql.Date/Time/Timestamp` objects.