### PR TITLE
[CALCITE-5443] Reset update count when checking for more results

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaStatement.java
@@ -475,6 +475,7 @@ public abstract class AvaticaStatement
     if (openResultSet != null) {
       openResultSet.close();
     }
+    updateCount = -1;
     return false;
   }
 


### PR DESCRIPTION
Modifies `AvaticaStatement#getMoreResults()` to match the requirement from the JavaDoc indicating that subsequent calls to `getUpdateCount()` should return `-1`.