### PR TITLE
[CALCITE-5536] Clean up some of the magic numbers in AvaticaResultSetConversionsTest and AbstractCursor

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/AbstractCursor.java
@@ -173,14 +173,14 @@ public abstract class AbstractCursor implements Cursor {
       default:
         throw new AssertionError("bad " + columnMetaData.type.rep);
       }
-    case 2013: // TIME_WITH_TIMEZONE
+    case Types.TIME_WITH_TIMEZONE:
       switch (columnMetaData.type.rep) {
       case STRING:
         return new StringAccessor(getter);
       default:
         throw new AssertionError("bad " + columnMetaData.type.rep);
       }
-    case 2014: // TIMESTAMP_WITH_TIMEZONE
+    case Types.TIMESTAMP_WITH_TIMEZONE:
       switch (columnMetaData.type.rep) {
       case STRING:
         return new StringAccessor(getter);

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
@@ -71,6 +71,29 @@ import static org.junit.Assert.fail;
  */
 @RunWith(Parameterized.class)
 public class AvaticaResultSetConversionsTest {
+
+  // UTC: 2016-10-10 20:18:38.123
+  // October 10 is considered DST in all time zones that observe DST (both hemispheres), so tests
+  // using this value will cover daylight time zone conversion when run in a location that observes
+  // DST. This is just a matter of coverage; all tests must succeed no matter where the host is.
+  private static final long DST_INSTANT = 1476130718123L;
+  private static final String DST_DATE_STRING = "2016-10-10";
+  private static final String DST_TIME_STRING = "20:18:38";
+  private static final String DST_TIMESTAMP_STRING = "2016-10-10 20:18:38";
+
+  // UTC: 2016-11-14 11:32:03.242
+  // There is no date where all time zones (both hemispheres) are on standard time, but all northern
+  // time zones observe standard time by mid-November. Tests using this value may or may not
+  // exercise standard time zone conversion, but this is just a matter of coverage; all tests must
+  // succeed no matter where the host is.
+  private static final long STANDARD_INSTANT = 1479123123242L;
+
+  // UTC: 00:24:36.123
+  private static final long VALID_TIME = 1476123L;
+
+  // UTC: 41:05:12.242
+  private static final long OVERFLOW_TIME = 147912242L;
+
   /**
    * A fake test driver for test.
    */
@@ -215,15 +238,15 @@ public class AvaticaResultSetConversionsTest {
       List<Object> row = Collections.<Object>singletonList(
           new Object[] {
               true, (byte) 1, (short) 2, 3, 4L, 5.0f, 6.0d, "testvalue",
-              new Date(1476130718123L), new Time(1476130718123L),
-              new Timestamp(1476130718123L),
+              new Date(DST_INSTANT), new Time(DST_INSTANT),
+              new Timestamp(DST_INSTANT),
               Arrays.asList(1, 2, 3),
               new StructImpl(Arrays.asList(42, false)),
               true,
               null,
               Arrays.asList(123, 18234),
-              Arrays.asList(1476130718123L, 1479123123242L),
-              Arrays.asList(1476123L, 147912242L),
+              Arrays.asList(DST_INSTANT, STANDARD_INSTANT),
+              Arrays.asList(VALID_TIME, OVERFLOW_TIME),
               Arrays.asList(1, 1.1)
           });
 
@@ -653,7 +676,7 @@ public class AvaticaResultSetConversionsTest {
           ColumnMetaData.scalar(Types.TIME, "TIME", ColumnMetaData.Rep.NUMBER);
       Array expectedArray =
           new ArrayFactoryImpl(TimeZone.getTimeZone("UTC")).createArray(
-              intType, Arrays.asList(1476123L, 147912242L));
+              intType, Arrays.asList(VALID_TIME, OVERFLOW_TIME));
       assertTrue(ArrayImpl.equalContents(expectedArray, g.getArray(resultSet)));
     }
   }
@@ -671,7 +694,7 @@ public class AvaticaResultSetConversionsTest {
           ColumnMetaData.scalar(Types.TIMESTAMP, "TIMESTAMP", ColumnMetaData.Rep.PRIMITIVE_LONG);
       Array expectedArray =
           new ArrayFactoryImpl(TimeZone.getTimeZone("UTC")).createArray(
-              intType, Arrays.asList(1476130718123L, 1479123123242L));
+              intType, Arrays.asList(DST_INSTANT, STANDARD_INSTANT));
       assertTrue(ArrayImpl.equalContents(expectedArray, g.getArray(resultSet)));
     }
   }
@@ -986,7 +1009,7 @@ public class AvaticaResultSetConversionsTest {
     }
 
     @Override public void testGetString(ResultSet resultSet) throws SQLException {
-      assertEquals("2016-10-10", g.getString(resultSet));
+      assertEquals(DST_DATE_STRING, g.getString(resultSet));
     }
 
     @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
@@ -1010,7 +1033,7 @@ public class AvaticaResultSetConversionsTest {
     }
 
     @Override public void testGetDate(ResultSet resultSet, Calendar calendar) throws SQLException {
-      assertEquals(new Date(1476130718123L), g.getDate(resultSet, calendar));
+      assertEquals(new Date(DST_INSTANT), g.getDate(resultSet, calendar));
     }
   }
 
@@ -1023,7 +1046,7 @@ public class AvaticaResultSetConversionsTest {
     }
 
     @Override public void testGetString(ResultSet resultSet) throws SQLException {
-      assertEquals("20:18:38", g.getString(resultSet));
+      assertEquals(DST_TIME_STRING, g.getString(resultSet));
     }
 
     @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
@@ -1031,23 +1054,23 @@ public class AvaticaResultSetConversionsTest {
     }
 
     @Override public void testGetByte(ResultSet resultSet) throws SQLException {
-      assertEquals((byte) -85, g.getByte(resultSet));
+      assertEquals((byte) DST_INSTANT, g.getByte(resultSet));
     }
 
     @Override public void testGetShort(ResultSet resultSet) throws SQLException {
-      assertEquals((short) -20053, g.getShort(resultSet));
+      assertEquals((short) (DST_INSTANT % DateTimeUtils.MILLIS_PER_DAY), g.getShort(resultSet));
     }
 
     @Override public void testGetInt(ResultSet resultSet) throws SQLException {
-      assertEquals(73118123, g.getInt(resultSet));
+      assertEquals((int) (DST_INSTANT % DateTimeUtils.MILLIS_PER_DAY), g.getInt(resultSet));
     }
 
     @Override public void testGetLong(ResultSet resultSet) throws SQLException {
-      assertEquals(73118123, g.getLong(resultSet));
+      assertEquals(DST_INSTANT % DateTimeUtils.MILLIS_PER_DAY, g.getLong(resultSet));
     }
 
     @Override public void testGetTime(ResultSet resultSet, Calendar calendar) throws SQLException {
-      assertEquals(new Time(1476130718123L), g.getTime(resultSet, calendar));
+      assertEquals(new Time(DST_INSTANT), g.getTime(resultSet, calendar));
     }
   }
 
@@ -1060,7 +1083,7 @@ public class AvaticaResultSetConversionsTest {
     }
 
     @Override public void testGetString(ResultSet resultSet) throws SQLException {
-      assertEquals("2016-10-10 20:18:38", g.getString(resultSet));
+      assertEquals(DST_TIMESTAMP_STRING, g.getString(resultSet));
     }
 
     @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
@@ -1068,32 +1091,32 @@ public class AvaticaResultSetConversionsTest {
     }
 
     @Override public void testGetByte(ResultSet resultSet) throws SQLException {
-      assertEquals((byte) -85, g.getByte(resultSet));
+      assertEquals((byte) DST_INSTANT, g.getByte(resultSet));
     }
 
     @Override public void testGetShort(ResultSet resultSet) throws SQLException {
-      assertEquals((short) 16811, g.getShort(resultSet));
+      assertEquals((short) DST_INSTANT, g.getShort(resultSet));
     }
 
     @Override public void testGetInt(ResultSet resultSet) throws SQLException {
-      assertEquals(-1338031701, g.getInt(resultSet));
+      assertEquals((int) DST_INSTANT, g.getInt(resultSet));
     }
 
     @Override public void testGetLong(ResultSet resultSet) throws SQLException {
-      assertEquals(1476130718123L, g.getLong(resultSet));
+      assertEquals(DST_INSTANT, g.getLong(resultSet));
     }
 
     @Override public void testGetDate(ResultSet resultSet, Calendar calendar) throws SQLException {
-      assertEquals(new Date(1476130718123L), g.getDate(resultSet, calendar));
+      assertEquals(new Date(DST_INSTANT), g.getDate(resultSet, calendar));
     }
 
     @Override public void testGetTime(ResultSet resultSet, Calendar calendar) throws SQLException {
-      assertEquals(new Time(1476130718123L), g.getTime(resultSet, calendar));
+      assertEquals(new Time(DST_INSTANT), g.getTime(resultSet, calendar));
     }
 
     @Override public void testGetTimestamp(ResultSet resultSet, Calendar calendar)
         throws SQLException {
-      assertEquals(new Timestamp(1476130718123L), g.getTimestamp(resultSet, calendar));
+      assertEquals(new Timestamp(DST_INSTANT), g.getTimestamp(resultSet, calendar));
     }
   }
 
@@ -1110,7 +1133,7 @@ public class AvaticaResultSetConversionsTest {
     }
   }
 
-  private static final Calendar DEFAULT_CALENDAR = DateTimeUtils.calendar();
+  private static final Calendar UTC_CALENDAR = DateTimeUtils.calendar();
 
   private static Connection connection = null;
   private static ResultSet resultSet = null;
@@ -1282,17 +1305,17 @@ public class AvaticaResultSetConversionsTest {
 
   @Test
   public void testGetDate() throws SQLException {
-    testHelper.testGetDate(resultSet, DEFAULT_CALENDAR);
+    testHelper.testGetDate(resultSet, UTC_CALENDAR);
   }
 
   @Test
   public void testGetTime() throws SQLException {
-    testHelper.testGetTime(resultSet, DEFAULT_CALENDAR);
+    testHelper.testGetTime(resultSet, UTC_CALENDAR);
   }
 
   @Test
   public void testGetTimestamp() throws SQLException {
-    testHelper.testGetTimestamp(resultSet, DEFAULT_CALENDAR);
+    testHelper.testGetTimestamp(resultSet, UTC_CALENDAR);
   }
 
   @Test

--- a/core/src/test/java/org/apache/calcite/avatica/util/TimestampAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/TimestampAccessorTest.java
@@ -41,6 +41,14 @@ public class TimestampAccessorTest {
   private static final Calendar UTC =
       Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.ROOT);
 
+  // UTC: 2014-09-30 15:28:27.356
+  private static final long DST_INSTANT = 1412090907356L;
+  private static final String DST_STRING = "2014-09-30 15:28:27";
+
+  // UTC: 1500-04-30 12:00:00.123 (PROLEPTIC GREGORIAN CALENDAR)
+  private static final long PRE_GREG_INSTANT = -14820580799877L;
+  private static final String PRE_GREG_STRING = "1500-04-30 12:00:00";
+
   private Cursor.Accessor instance;
   private Calendar localCalendar;
   private Timestamp value;
@@ -191,11 +199,11 @@ public class TimestampAccessorTest {
     value = new Timestamp(0L);
     assertThat(instance.getString(), is("1970-01-01 00:00:00"));
 
-    value = new Timestamp(1412090907356L /* 2014-09-30 15:28:27.356 UTC */);
-    assertThat(instance.getString(), is("2014-09-30 15:28:27"));
+    value = new Timestamp(DST_INSTANT);
+    assertThat(instance.getString(), is(DST_STRING));
 
-    value = new Timestamp(-14820580799877L /* 1500-04-30 12:00:00.123 */);
-    assertThat(instance.getString(), is("1500-04-30 12:00:00"));
+    value = new Timestamp(PRE_GREG_INSTANT);
+    assertThat(instance.getString(), is(PRE_GREG_STRING));
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/avatica/util/TimestampFromNumberAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/TimestampFromNumberAccessorTest.java
@@ -37,6 +37,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class TimestampFromNumberAccessorTest {
 
+  // UTC: 2014-09-30 15:28:27.356
+  private static final long DST_INSTANT = 1412090907356L;
+  private static final String DST_STRING = "2014-09-30 15:28:27";
+
+  // UTC: 1500-04-30 12:00:00.123 (JULIAN CALENDAR)
+  private static final long PRE_GREG_INSTANT = -14821444799877L;
+  private static final String PRE_GREG_STRING = "1500-04-30 12:00:00";
+
   private Cursor.Accessor instance;
   private Calendar localCalendar;
   private Object value;
@@ -48,8 +56,7 @@ public class TimestampFromNumberAccessorTest {
   @Before public void before() {
     final AbstractCursor.Getter getter = new LocalGetter();
     localCalendar = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
-    instance = new AbstractCursor.TimestampFromNumberAccessor(getter,
-        localCalendar);
+    instance = new AbstractCursor.TimestampFromNumberAccessor(getter, localCalendar);
   }
 
   /**
@@ -126,11 +133,11 @@ public class TimestampFromNumberAccessorTest {
     value = 0L;
     assertThat(instance.getString(), is("1970-01-01 00:00:00"));
 
-    value = 1412090907356L;  // 2014-09-30 15:28:27.356 UTC
-    assertThat(instance.getString(), is("2014-09-30 15:28:27"));
+    value = DST_INSTANT;
+    assertThat(instance.getString(), is(DST_STRING));
 
-    value = -14821444799877L;  // 1500-04-30 12:00:00.123
-    assertThat(instance.getString(), is("1500-04-30 12:00:00"));
+    value = PRE_GREG_INSTANT;
+    assertThat(instance.getString(), is(PRE_GREG_STRING));
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/avatica/util/TimestampFromUtilDateAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/TimestampFromUtilDateAccessorTest.java
@@ -42,6 +42,14 @@ public class TimestampFromUtilDateAccessorTest {
   private static final Calendar UTC =
       Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.ROOT);
 
+  // UTC: 2014-09-30 15:28:27.356
+  private static final long DST_INSTANT = 1412090907356L;
+  private static final String DST_STRING = "2014-09-30 15:28:27";
+
+  // UTC: 1500-04-30 12:00:00.123 (PROLEPTIC GREGORIAN CALENDAR)
+  private static final long PRE_GREG_INSTANT = -14820580799877L;
+  private static final String PRE_GREG_STRING = "1500-04-30 12:00:00";
+
   private Cursor.Accessor instance;
   private Calendar localCalendar;
   private Date value;
@@ -194,11 +202,11 @@ public class TimestampFromUtilDateAccessorTest {
     value = new Timestamp(0L);
     assertThat(instance.getString(), is("1970-01-01 00:00:00"));
 
-    value = new Timestamp(1412090907356L /* 2014-09-30 15:28:27.356 UTC */);
-    assertThat(instance.getString(), is("2014-09-30 15:28:27"));
+    value = new Timestamp(DST_INSTANT);
+    assertThat(instance.getString(), is(DST_STRING));
 
-    value = new Timestamp(-14820580799877L /* 1500-04-30 12:00:00.123 UTC */);
-    assertThat(instance.getString(), is("1500-04-30 12:00:00"));
+    value = new Timestamp(PRE_GREG_INSTANT);
+    assertThat(instance.getString(), is(PRE_GREG_STRING));
   }
 
   /**


### PR DESCRIPTION
Turn a bunch of magic numbers into named constants without changing any values, and add extra comments where appropriate.

In `AvaticaResultSetConversionsTest`, I renamed `DEFAULT_CALENDAR` to `UTC_CALENDAR` because that's a more accurate name. The definition of `DateTimeUtils.calendar()` is `Calendar.getInstance(UTC_ZONE, Locale.ROOT)`.