### PR TITLE
Apply same vcs.xml as for Calcite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/.editorconfig
 *~
 /.idea
+!/.idea/vcs.xml
 *.iml
 settings.xml
 .classpath.txt

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+    <component name="CommitMessageInspectionProfile">
+        <profile version="1.0">
+            <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+            <inspection_tool class="SubjectBodySeparation" enabled="true" level="ERROR" enabled_by_default="true" />
+            <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+        </profile>
+    </component>
+    <component name="IssueNavigationConfiguration">
+        <option name="links">
+            <list>
+                <IssueNavigationLink>
+                    <option name="issueRegexp" value="[A-Z]+\-\d+" />
+                    <option name="linkRegexp" value="https://issues.apache.org/jira/browse/$0" />
+                </IssueNavigationLink>
+                <IssueNavigationLink>
+                    <option name="issueRegexp" value="(apache/calcite)?#(\d+)" />
+                    <option name="linkRegexp" value="https://github.com/apache/calcite-avatica/pull/$2" />
+                </IssueNavigationLink>
+            </list>
+        </option>
+    </component>
+    <component name="VcsDirectoryMappings">
+        <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    </component>
+</project>

--- a/.ratignore
+++ b/.ratignore
@@ -1,6 +1,7 @@
 **/.gitattributes
 **/.gitignore
 .ratignore
+.idea/vcs.xml
 # Third-party license files
 src/main/config/licenses/
 #


### PR DESCRIPTION
This is almost a cherry-pick (link to GitHub changed to Avatica's repo) from Calcite to have links to JIRA/GitHub in IDEA and enable commit inspection enabled