### PR TITLE
[CALCITE-6141] Add jdk8.checkstyle property, use jdk8.checkstyle in case of java 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 50
       - name: 'Test'
         run: |
-          ./gradlew --no-parallel --no-daemon tasks build javadoc -Pcheckstyle.version=9.3
+          ./gradlew --no-parallel --no-daemon tasks build javadoc
 
   linux-jdk8-avatica:
     name: 'Linux (JDK 8), Avatica main'
@@ -74,7 +74,7 @@ jobs:
         fetch-depth: 50
     - name: 'Install Avatica to Maven Local'
       run: |
-        ./gradlew publishToMavenLocal -Pcalcite.avatica.version=1.0.0-dev-main -PskipJavadoc -Pcheckstyle.version=9.3
+        ./gradlew publishToMavenLocal -Pcalcite.avatica.version=1.0.0-dev-main -PskipJavadoc
     - name: 'Test Calcite'
       run: |
         git clone --depth 100 https://github.com/apache/calcite.git ../calcite

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -209,7 +209,9 @@ allprojects {
     if (!skipCheckstyle) {
         apply<CheckstylePlugin>()
         dependencies {
-            checkstyle("com.puppycrawl.tools:checkstyle:${"checkstyle".v}")
+            val checkstyleVersion = if (JavaVersion.current() == JavaVersion.VERSION_1_8)
+                "jdk8.checkstyle".v else "checkstyle".v
+            checkstyle("com.puppycrawl.tools:checkstyle:$checkstyleVersion")
         }
         checkstyle {
             // Current one is ~8.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,6 +51,7 @@ org.owasp.dependencycheck.version=5.2.2
 # Tools
 checkerframework.version=3.10.0
 checkstyle.version=10.3.2
+jdk8.checkstyle.version=9.3
 spotbugs.version=3.1.11
 
 asm.version=7.1


### PR DESCRIPTION
The idea is to use `jdk8.checkstyle.version` gradle property which will be used in case of java 8
for other java version `checstyle.version` will be used
This allows to compile Avatica with java 8 without explicitly set checkstyle version

also mentioned at https://lists.apache.org/thread/r27kdvvhr0222nqlog7xzn5y3yjvz6jp