### PR TITLE
Add Calcite CLI tool to list of Avatica Clients on website

### DIFF
--- a/site/_docs/index.md
+++ b/site/_docs/index.md
@@ -181,3 +181,10 @@ highly welcomed!
 * *License*: [MIT](https://opensource.org/licenses/MIT)
 * Any Avatica version
 * *Maintainer*: Waylay.io
+
+### Calcite Avatica CLI: A Go-based Toool
+* [Home page](https://github.com/satyakommula96/calcite-cli)
+* Language: Go
+* *License*: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+* Avatica version 1.8.0 onwards
+* *Maintainer*: [Satya Kommula](https://github.com/satyakommula96)


### PR DESCRIPTION
Please review the initial integration of the Calcite CLI tool using Go in list of clients . If any adjustments are needed, kindly let me know. @F21

Thanks.