### PR TITLE
[CALCITE-6656] Update owasp plugin from 5.2.2 to 10.0.4 in Avatica

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,7 @@ val enableSpotBugs = props.bool("spotbugs", default = false)
 val skipCheckstyle by props()
 val skipAutostyle by props()
 val skipJavadoc by props()
+var nvdApiKey: String? = props.string("nvdApiKey")
 // Inherited from stage-vote-release-plugin: skipSign, useGpgCmd
 val enableMavenLocal by props()
 val enableGradleMetadata by props()
@@ -164,6 +165,15 @@ val javadocAggregateIncludingTests by tasks.registering(Javadoc::class) {
     setDestinationDir(file(layout.buildDirectory.get().file("docs/javadocAggregateIncludingTests")))
 }
 
+if (nvdApiKey != null) {
+    apply(plugin = "org.owasp.dependencycheck")
+    dependencyCheck {
+        nvd {
+            apiKey = nvdApiKey
+        }
+    }
+}
+
 allprojects {
     group = "org.apache.calcite.avatica"
     version = buildVersion
@@ -236,6 +246,7 @@ allprojects {
         fileMode = "664".toInt(8)
     }
 
+    tasks.register<DependencyReportTask>("allDependencies") {}
     tasks {
         withType<Javadoc>().configureEach {
             (options as StandardJavadocDocletOptions).apply {

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,8 @@ com.google.protobuf.version=0.8.12
 de.thetaphi.forbiddenapis.version=3.7
 org.jetbrains.gradle.plugin.idea-ext.version=0.5
 org.nosphere.apache.rat.version=0.8.0
-org.owasp.dependencycheck.version=5.2.2
+#Last version to support Java 8
+org.owasp.dependencycheck.version=10.0.4
 
 # TODO
 # error_prone_core.version=2.3.3


### PR DESCRIPTION
also add option to specify NVD API key
also add target to analyze depencies in all modules