### PR TITLE
[CALCITE-6670] Use org.apache.calcite.avatica.shaded as base package …

### DIFF
--- a/shaded/core/build.gradle.kts
+++ b/shaded/core/build.gradle.kts
@@ -72,7 +72,7 @@ tasks {
             "org.apache.http",
             "org.apache.commons"
         ).forEach {
-            relocate(it, "${project.group}.$it")
+            relocate(it, "${project.group}.shaded.$it")
         }
         CrLfSpec(LineEndings.LF).run {
             into("META-INF") {


### PR DESCRIPTION
…for relocated libraries