### PR TITLE
[CALCITE-6697] Update Scott-data-hsqldb from 0.1 to 0.2 in Avatica

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -76,6 +76,6 @@ kerby.version=1.1.1
 log4j2.version=2.17.1
 mockito.version=4.11.0
 protobuf.version=3.25.5
-scott-data-hsqldb.version=0.1
+scott-data-hsqldb.version=0.2
 servlet.version=4.0.1
 slf4j.version=1.7.25


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-6697