### PR TITLE
[CALCITE-6781] The isUpdateCapable method of calcite.avatica will incorrectly traverse the returned result value

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
@@ -614,18 +614,20 @@ public abstract class AvaticaConnection implements Connection {
       return;
     }
     if (signature.statementType.canUpdate() && statement.updateCount == -1) {
-      statement.openResultSet.next();
-      Object obj = statement.openResultSet.getObject(ROWCOUNT_COLUMN_NAME);
-      if (obj instanceof Number) {
-        statement.updateCount = ((Number) obj).intValue();
-      } else if (obj instanceof List) {
-        @SuppressWarnings("unchecked")
-        final List<Number> numbers = (List<Number>) obj;
-        statement.updateCount = numbers.get(0).intValue();
-      } else {
-        throw HELPER.createException("Not a valid return result.");
+      if (statement.openResultSet.next()) {
+        statement.openResultSet.next();
+        Object obj = statement.openResultSet.getObject(ROWCOUNT_COLUMN_NAME);
+        if (obj instanceof Number) {
+          statement.updateCount = ((Number) obj).intValue();
+        } else if (obj instanceof List) {
+          @SuppressWarnings("unchecked")
+          final List<Number> numbers = (List<Number>) obj;
+          statement.updateCount = numbers.get(0).intValue();
+        } else {
+          throw HELPER.createException("Not a valid return result.");
+        }
+        statement.openResultSet = null;
       }
-      statement.openResultSet = null;
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java
@@ -615,7 +615,6 @@ public abstract class AvaticaConnection implements Connection {
     }
     if (signature.statementType.canUpdate() && statement.updateCount == -1) {
       if (statement.openResultSet.next()) {
-        statement.openResultSet.next();
         Object obj = statement.openResultSet.getObject(ROWCOUNT_COLUMN_NAME);
         if (obj instanceof Number) {
           statement.updateCount = ((Number) obj).intValue();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-6781

Recently I am adapting the delete statement of es, but when I support delete * from where condition and similar statements, an error will be reported in the isUpdateCapable method, as follows
`java.util.NoSuchElementException: Expecting cursor position to be Position.OK, actual is Position.AFTER_END`

The reason is that the openResultSet.next() of the delete statement is false. In the current isUpdateCapable method, whether openResultSet.next() is true or false, it will perform subsequent operations.
But when openResultSet.next() is false,

`statement.openResultSet.getObject(ROWCOUNT_COLUMN_NAME)`
will throw the exception I encountered above

So when openResultSet.next() is false, it should return null directly.

I am not very familiar with the avatica module, and I am not sure where to add the test

I also have a second solution signature.statementType.canUpdate() returns false which can also solve this problem