### PR TITLE
[CALCITE-6808] Use JDK23 instead of JDK22 in CI test for latest JVM i…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,14 +204,14 @@ jobs:
       run: |
         ./gradlew --no-parallel --no-daemon tasks build javadoc
 
-  linux-jdk22:
-    name: 'Linux (JDK 22)'
+  linux-jdk23:
+    name: 'Linux (JDK 23)'
     runs-on: ubuntu-latest
     steps:
-      - name: 'Set up JDK 22'
+      - name: 'Set up JDK 23'
         uses: actions/setup-java@v4
         with:
-          java-version: 22
+          java-version: 23
           distribution: 'zulu'
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
…n Avatica