### PR TITLE
[CALCITE-5136] Avatica build (or CI) must fail if there are deprecation warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -404,6 +404,7 @@ allprojects {
 
             withType<JavaCompile>().configureEach {
                 options.encoding = "UTF-8"
+                options.compilerArgs.addAll(listOf("-Xlint:deprecation,-options", "-Werror"))
             }
             withType<Test>().configureEach {
                 testLogging {

--- a/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
+++ b/core/src/main/java/org/apache/calcite/avatica/BuiltInConnectionProperty.java
@@ -18,7 +18,6 @@ package org.apache.calcite.avatica;
 
 import org.apache.calcite.avatica.ha.ShuffledRoundRobinLBStrategy;
 import org.apache.calcite.avatica.remote.AvaticaHttpClientFactoryImpl;
-import org.apache.calcite.avatica.remote.HostnameVerificationConfigurable.HostnameVerification;
 
 import org.apache.hc.core5.util.Timeout;
 
@@ -92,8 +91,13 @@ public enum BuiltInConnectionProperty implements ConnectionProperty {
   /** Password for the key inside keystore */
   KEY_PASSWORD("key_password", Type.STRING, "", false),
 
-  HOSTNAME_VERIFICATION("hostname_verification", Type.ENUM, HostnameVerification.STRICT,
-      HostnameVerification.class, false),
+  @SuppressWarnings("deprecation")
+  HOSTNAME_VERIFICATION("hostname_verification", Type.ENUM,
+      org.apache.calcite.avatica.remote.
+          HostnameVerificationConfigurable.HostnameVerification.STRICT,
+      org.apache.calcite.avatica.remote.
+          HostnameVerificationConfigurable.HostnameVerification.class,
+      false),
 
   TRANSPARENT_RECONNECTION("transparent_reconnection", Type.BOOLEAN, Boolean.FALSE, false),
 

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfig.java
@@ -18,7 +18,6 @@ package org.apache.calcite.avatica;
 
 import org.apache.calcite.avatica.ha.LBStrategy;
 import org.apache.calcite.avatica.remote.AvaticaHttpClientFactory;
-import org.apache.calcite.avatica.remote.HostnameVerificationConfigurable.HostnameVerification;
 import org.apache.calcite.avatica.remote.Service;
 
 import java.io.File;
@@ -64,7 +63,9 @@ public interface ConnectionConfig {
   /** @see BuiltInConnectionProperty#KEY_PASSWORD */
   String keyPassword();
   /** @see BuiltInConnectionProperty#HOSTNAME_VERIFICATION */
-  HostnameVerification hostnameVerification();
+  @SuppressWarnings("deprecation")
+  org.apache.calcite.avatica.remote.
+      HostnameVerificationConfigurable.HostnameVerification hostnameVerification();
   /** @see BuiltInConnectionProperty#TRANSPARENT_RECONNECTION */
   boolean transparentReconnectionEnabled();
   /** @see BuiltInConnectionProperty#FETCH_SIZE */

--- a/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/ConnectionConfigImpl.java
@@ -18,7 +18,6 @@ package org.apache.calcite.avatica;
 
 import org.apache.calcite.avatica.ha.LBStrategy;
 import org.apache.calcite.avatica.remote.AvaticaHttpClientFactory;
-import org.apache.calcite.avatica.remote.HostnameVerificationConfigurable.HostnameVerification;
 import org.apache.calcite.avatica.remote.Service;
 
 import java.io.File;
@@ -130,9 +129,12 @@ public class ConnectionConfigImpl implements ConnectionConfig {
 
   }
 
-  public HostnameVerification hostnameVerification() {
+  @SuppressWarnings("deprecation")
+  public org.apache.calcite.avatica.remote.
+      HostnameVerificationConfigurable.HostnameVerification hostnameVerification() {
     return BuiltInConnectionProperty.HOSTNAME_VERIFICATION.wrap(properties)
-        .getEnum(HostnameVerification.class);
+        .getEnum(org.apache.calcite.avatica.remote.
+            HostnameVerificationConfigurable.HostnameVerification.class);
   }
 
   @Override public boolean transparentReconnectionEnabled() {

--- a/core/src/main/java/org/apache/calcite/avatica/remote/AvaticaHttpClientFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/avatica/remote/AvaticaHttpClientFactoryImpl.java
@@ -53,6 +53,7 @@ public class AvaticaHttpClientFactoryImpl implements AvaticaHttpClientFactory {
     return INSTANCE;
   }
 
+  @SuppressWarnings("deprecation")
   @Override public AvaticaHttpClient getClient(URL url, ConnectionConfig config,
       KerberosConnection kerberosUtil) {
     String className = config.httpClientClass();

--- a/core/src/main/java/org/apache/calcite/avatica/remote/CommonsHttpClientPoolCache.java
+++ b/core/src/main/java/org/apache/calcite/avatica/remote/CommonsHttpClientPoolCache.java
@@ -17,7 +17,6 @@
 package org.apache.calcite.avatica.remote;
 
 import org.apache.calcite.avatica.ConnectionConfig;
-import org.apache.calcite.avatica.remote.HostnameVerificationConfigurable.HostnameVerification;
 
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
@@ -128,11 +127,15 @@ public class CommonsHttpClientPoolCache {
    * @throws IllegalArgumentException if the provided verification cannot be
    *                                  handled.
    */
-  private static HostnameVerifier getHostnameVerifier(HostnameVerification verification) {
+  @SuppressWarnings("deprecation")
+  private static HostnameVerifier getHostnameVerifier(
+      org.apache.calcite.avatica.remote.
+          HostnameVerificationConfigurable.HostnameVerification verification) {
     // Normally, the configuration logic would give us a default of STRICT if it was
     // not provided by the user. It's easy for us to do a double-check.
     if (verification == null) {
-      verification = HostnameVerification.STRICT;
+      verification = org.apache.calcite.avatica.remote.
+          HostnameVerificationConfigurable.HostnameVerification.STRICT;
     }
     switch (verification) {
     case STRICT:

--- a/core/src/main/java/org/apache/calcite/avatica/remote/Driver.java
+++ b/core/src/main/java/org/apache/calcite/avatica/remote/Driver.java
@@ -28,6 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -156,8 +158,8 @@ public class Driver extends UnregisteredDriver {
       urlStr = config.url();
     }
     try {
-      url = new URL(urlStr);
-    } catch (MalformedURLException e) {
+      url = new URI(urlStr).toURL();
+    } catch (MalformedURLException | URISyntaxException e) {
       throw new RuntimeException(e);
     }
 

--- a/core/src/main/java/org/apache/calcite/avatica/util/Sources.java
+++ b/core/src/main/java/org/apache/calcite/avatica/util/Sources.java
@@ -59,8 +59,8 @@ public abstract class Sources {
 
   public static Source url(String url) {
     try {
-      return of(new URL(url));
-    } catch (MalformedURLException | IllegalArgumentException e) {
+      return of(new URI(url).toURL());
+    } catch (MalformedURLException | IllegalArgumentException | URISyntaxException e) {
       throw new RuntimeException("Malformed URL: '" + url + "'", e);
     }
   }
@@ -133,11 +133,7 @@ public abstract class Sources {
           filePath += "/";
         }
         try {
-          // We need to encode path. For instance, " " should become "%20"
-          // That is why java.net.URLEncoder.encode(java.lang.String, java.lang.String) is not
-          // suitable because it replaces " " with "+".
-          String encodedPath = new URI(null, null, filePath, null).getRawPath();
-          return new URL("file", null, 0, encodedPath);
+          return new URI("file", filePath, null).toURL();
         } catch (MalformedURLException | URISyntaxException e) {
           throw new IllegalArgumentException("Unable to create URL for file " + filePath, e);
         }

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedTestBase.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaClosedTestBase.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 /**

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
@@ -60,9 +60,9 @@ import java.util.Properties;
 import java.util.TimeZone;
 
 import static org.hamcrest.CoreMatchers.isA;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetThrowsSqlExceptionTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetThrowsSqlExceptionTest.java
@@ -16,9 +16,7 @@
  */
 package org.apache.calcite.avatica;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -27,6 +25,7 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -35,9 +34,6 @@ import static org.junit.Assert.assertTrue;
  * and {@link ResultSet#updateNull}, for example.
  */
 public class AvaticaResultSetThrowsSqlExceptionTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   /**
    * A fake test driver for test.
@@ -81,8 +77,7 @@ public class AvaticaResultSetThrowsSqlExceptionTest {
     try (Connection connection = driver.connect("jdbc:test", properties);
          ResultSet resultSet =
              connection.createStatement().executeQuery("SELECT * FROM TABLE")) {
-      thrown.expect(SQLFeatureNotSupportedException.class);
-      resultSet.previous();
+      assertThrows(SQLFeatureNotSupportedException.class, resultSet::previous);
     }
   }
 
@@ -94,8 +89,7 @@ public class AvaticaResultSetThrowsSqlExceptionTest {
     try (Connection connection = driver.connect("jdbc:test", properties);
          ResultSet resultSet =
              connection.createStatement().executeQuery("SELECT * FROM TABLE")) {
-      thrown.expect(SQLFeatureNotSupportedException.class);
-      resultSet.updateNull(1);
+      assertThrows(SQLFeatureNotSupportedException.class, () -> resultSet.updateNull(1));
     }
   }
 
@@ -119,8 +113,7 @@ public class AvaticaResultSetThrowsSqlExceptionTest {
     assertTrue(resultSet.isClosed());
 
     // once closed, next should fail
-    thrown.expect(SQLException.class);
-    resultSet.next();
+    assertThrows(SQLException.class, resultSet::next);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/avatica/ConnectionConfigImplTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/ConnectionConfigImplTest.java
@@ -22,10 +22,10 @@ import java.io.File;
 import java.nio.file.Paths;
 import java.util.Properties;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 /**
  * Test class for {@link ConnectionConfigImpl}.

--- a/core/src/test/java/org/apache/calcite/avatica/ConnectionPropertiesImplTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/ConnectionPropertiesImplTest.java
@@ -20,8 +20,8 @@ import org.junit.Test;
 
 import java.util.Objects;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * Test class for {@link ConnectionPropertiesImpl}.

--- a/core/src/test/java/org/apache/calcite/avatica/MetaImplCreateIterableTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/MetaImplCreateIterableTest.java
@@ -52,6 +52,7 @@ public class MetaImplCreateIterableTest {
       return null;
     }
 
+    @Deprecated
     @Override public ExecuteResult prepareAndExecute(StatementHandle h, String sql,
         long maxRowCount,
         PrepareCallback callback) {
@@ -87,6 +88,7 @@ public class MetaImplCreateIterableTest {
       return new Frame(offset, done, next);
     }
 
+    @Deprecated
     @Override public ExecuteResult execute(StatementHandle h, List<TypedValue> parameterValues,
         long maxRowCount)
         throws NoSuchStatementException {

--- a/core/src/test/java/org/apache/calcite/avatica/UnregisteredDriverTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/UnregisteredDriverTest.java
@@ -16,34 +16,32 @@
  */
 package org.apache.calcite.avatica;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.sql.Driver;
 import java.sql.SQLException;
 import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Test class for {@link UnregisteredDriver}.
  */
 public class UnregisteredDriverTest {
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
-  @Test public void testAcceptsURLWithNull() throws SQLException {
+  @Test public void testAcceptsURLWithNull() {
     final Driver driver = new UnregisteredTestDriver();
-    thrown.expect(SQLException.class);
-    thrown.expectMessage("url can not be null!");
-    driver.acceptsURL(null);
+    SQLException thrown = assertThrows(SQLException.class, () -> driver.acceptsURL(null));
+    assertThat(thrown.getMessage(), containsString("url can not be null!"));
   }
 
-  @Test public void testConnectWithNullURL() throws SQLException {
+  @Test public void testConnectWithNullURL() {
     final Driver driver = new UnregisteredTestDriver();
-    thrown.expect(SQLException.class);
-    thrown.expectMessage("url can not be null!");
-    driver.connect(null, new Properties());
+    SQLException thrown = assertThrows(SQLException.class,
+        () -> driver.connect(null, new Properties()).close());
+    assertThat(thrown.getMessage(), containsString("url can not be null!"));
   }
 
   private static final class UnregisteredTestDriver extends UnregisteredDriver {

--- a/core/src/test/java/org/apache/calcite/avatica/remote/AvaticaCommonsHttpClientImplTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/remote/AvaticaCommonsHttpClientImplTest.java
@@ -33,7 +33,7 @@ import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayInputStream;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -72,7 +72,7 @@ public class AvaticaCommonsHttpClientImplTest {
     };
 
     final AvaticaCommonsHttpClientImpl client =
-            spy(new AvaticaCommonsHttpClientImpl(new URL("http://127.0.0.1")));
+            spy(new AvaticaCommonsHttpClientImpl(new URI("http://127.0.0.1")));
     client.setHttpClientPool(mock(PoolingHttpClientConnectionManager.class), mock(
         ConnectionConfig.class));
 
@@ -106,7 +106,7 @@ public class AvaticaCommonsHttpClientImplTest {
     };
 
     final AvaticaCommonsHttpClientImpl client =
-            spy(new AvaticaCommonsHttpClientImpl(new URL("http://127.0.0.1")));
+            spy(new AvaticaCommonsHttpClientImpl(new URI("http://127.0.0.1")));
     client.setHttpClientPool(mock(PoolingHttpClientConnectionManager.class), mock(
         ConnectionConfig.class));
 
@@ -125,7 +125,7 @@ public class AvaticaCommonsHttpClientImplTest {
   @Test
   public void testPersistentContextReusedAcrossRequests() throws Exception {
     final AvaticaCommonsHttpClientImpl client =
-        spy(new AvaticaCommonsHttpClientImpl(new URL("http://127.0.0.1")));
+        spy(new AvaticaCommonsHttpClientImpl(new URI("http://127.0.0.1")));
     client.setHttpClientPool(mock(PoolingHttpClientConnectionManager.class), mock(
         ConnectionConfig.class));
 
@@ -150,7 +150,7 @@ public class AvaticaCommonsHttpClientImplTest {
   @Test
   public void testPersistentContextThreadSafety() throws Exception {
     final AvaticaCommonsHttpClientImpl client =
-        spy(new AvaticaCommonsHttpClientImpl(new URL("http://127.0.0.1")));
+        spy(new AvaticaCommonsHttpClientImpl(new URI("http://127.0.0.1")));
     client.setHttpClientPool(mock(PoolingHttpClientConnectionManager.class), mock(
         ConnectionConfig.class));
 

--- a/core/src/test/java/org/apache/calcite/avatica/remote/AvaticaHttpClientFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/remote/AvaticaHttpClientFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.calcite.avatica.ConnectionConfigImpl;
 
 import org.junit.Test;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.Properties;
 
@@ -34,7 +35,7 @@ public class AvaticaHttpClientFactoryTest {
 
   @Test public void testDefaultHttpClient() throws Exception {
     Properties props = new Properties();
-    URL url = new URL("http://localhost:8765");
+    URL url = new URI("http://localhost:8765").toURL();
     ConnectionConfig config = new ConnectionConfigImpl(props);
     AvaticaHttpClientFactory httpClientFactory = new AvaticaHttpClientFactoryImpl();
 
@@ -47,7 +48,7 @@ public class AvaticaHttpClientFactoryTest {
     Properties props = new Properties();
     props.setProperty(BuiltInConnectionProperty.HTTP_CLIENT_IMPL.name(),
         AvaticaHttpClientImpl.class.getName());
-    URL url = new URL("http://localhost:8765");
+    URL url = new URI("http://localhost:8765").toURL();
     ConnectionConfig config = new ConnectionConfigImpl(props);
     AvaticaHttpClientFactory httpClientFactory = new AvaticaHttpClientFactoryImpl();
 
@@ -60,7 +61,7 @@ public class AvaticaHttpClientFactoryTest {
     Properties props = new Properties();
     props.setProperty(BuiltInConnectionProperty.HTTP_CLIENT_IMPL.name(),
         Properties.class.getName()); // Properties is intentionally *not* a valid class
-    URL url = new URL("http://localhost:8765");
+    URL url = new URI("http://localhost:8765").toURL();
     ConnectionConfig config = new ConnectionConfigImpl(props);
     AvaticaHttpClientFactory httpClientFactory = new AvaticaHttpClientFactoryImpl();
 

--- a/core/src/test/java/org/apache/calcite/avatica/remote/AvaticaHttpClientTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/remote/AvaticaHttpClientTest.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
@@ -41,7 +42,7 @@ public class AvaticaHttpClientTest {
   @Test
   public void testRetryOnUnavailable() throws Exception {
     // HTTP-503, try again
-    URL url = new URL("http://127.0.0.1:8765");
+    URL url = new URI("http://127.0.0.1:8765").toURL();
     final HttpURLConnection cnxn = Mockito.mock(HttpURLConnection.class);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     ByteArrayInputStream bais = new ByteArrayInputStream(RESPONSE.getBytes(StandardCharsets.UTF_8));
@@ -68,7 +69,7 @@ public class AvaticaHttpClientTest {
   @Test(expected = RuntimeException.class)
   public void testServerError() throws Exception {
     // HTTP 500 should error out
-    URL url = new URL("http://127.0.0.1:8765");
+    URL url = new URI("http://127.0.0.1:8765").toURL();
     final HttpURLConnection cnxn = Mockito.mock(HttpURLConnection.class);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
 

--- a/core/src/test/java/org/apache/calcite/avatica/remote/TypedValueTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/remote/TypedValueTest.java
@@ -45,10 +45,10 @@ import java.util.TimeZone;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/core/src/test/java/org/apache/calcite/avatica/test/AvaticaUtilsTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/test/AvaticaUtilsTest.java
@@ -40,10 +40,10 @@ import static org.apache.calcite.avatica.AvaticaUtils.skipFully;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**

--- a/core/src/test/java/org/apache/calcite/avatica/test/JsonHandlerTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/test/JsonHandlerTest.java
@@ -38,7 +38,7 @@ import java.util.Random;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests JSON encoding/decoding in the remote service.

--- a/core/src/test/java/org/apache/calcite/avatica/util/ArrayAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/ArrayAccessorTest.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.calcite.avatica.AvaticaMatchers.isArrayAccessorResult;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test class for verifying functionality in array accessor from abstract cursor.

--- a/core/src/test/java/org/apache/calcite/avatica/util/ArrayImplTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/ArrayImplTest.java
@@ -24,7 +24,6 @@ import org.apache.calcite.avatica.ColumnMetaData.StructType;
 import org.apache.calcite.avatica.MetaImpl;
 import org.apache.calcite.avatica.util.Cursor.Accessor;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.Array;
@@ -37,6 +36,7 @@ import java.util.Objects;
 
 import static org.apache.calcite.avatica.AvaticaMatchers.isArrayAccessorResult;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -61,7 +61,7 @@ public class ArrayImplTest {
       int rowid = 0;
       while (cursor.next()) {
         List<Object> expectedArray = rowsValues.get(rowid);
-        Assert.assertThat(accessor, isArrayAccessorResult(expectedArray, Integer.class));
+        assertThat(accessor, isArrayAccessorResult(expectedArray, Integer.class));
         rowid++;
       }
     }
@@ -82,7 +82,7 @@ public class ArrayImplTest {
       int rowid = 0;
       while (cursor.next()) {
         List<Object> expectedArray = rowsValues.get(rowid);
-        Assert.assertThat(accessor, isArrayAccessorResult(expectedArray, Float.class));
+        assertThat(accessor, isArrayAccessorResult(expectedArray, Float.class));
         rowid++;
       }
     }
@@ -103,7 +103,7 @@ public class ArrayImplTest {
       int rowid = 0;
       while (cursor.next()) {
         List<Object> expectedArray = rowsValues.get(rowid);
-        Assert.assertThat(accessor, isArrayAccessorResult(expectedArray, Double.class));
+        assertThat(accessor, isArrayAccessorResult(expectedArray, Double.class));
         rowid++;
       }
     }
@@ -124,7 +124,7 @@ public class ArrayImplTest {
       int rowid = 0;
       while (cursor.next()) {
         List<Object> expectedArray = rowsValues.get(rowid);
-        Assert.assertThat(accessor, isArrayAccessorResult(expectedArray, Double.class));
+        assertThat(accessor, isArrayAccessorResult(expectedArray, Double.class));
         rowid++;
       }
     }

--- a/server/src/main/java/org/apache/calcite/avatica/server/PropertyBasedSpnegoLoginService.java
+++ b/server/src/main/java/org/apache/calcite/avatica/server/PropertyBasedSpnegoLoginService.java
@@ -18,7 +18,6 @@ package org.apache.calcite.avatica.server;
 
 import org.eclipse.jetty.security.SpnegoUserPrincipal;
 import org.eclipse.jetty.server.UserIdentity;
-import org.eclipse.jetty.util.B64Code;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
@@ -65,7 +64,7 @@ public class PropertyBasedSpnegoLoginService extends org.eclipse.jetty.security.
   @Override public UserIdentity login(String username, Object credentials,
       ServletRequest request) {
     String encodedAuthToken = (String) credentials;
-    byte[] authToken = B64Code.decode(encodedAuthToken);
+    byte[] authToken = org.eclipse.jetty.util.B64Code.decode(encodedAuthToken);
 
     GSSManager manager = GSSManager.getInstance();
     try {

--- a/server/src/main/java/org/apache/calcite/avatica/server/SubjectPreservingPrivilegedThreadFactory.java
+++ b/server/src/main/java/org/apache/calcite/avatica/server/SubjectPreservingPrivilegedThreadFactory.java
@@ -47,6 +47,7 @@ class SubjectPreservingPrivilegedThreadFactory implements ThreadFactory {
     return SecurityUtils.doPrivileged(new PrivilegedAction<Thread>() {
       @Override public Thread run() {
         return SecurityUtils.callAs(subject, new Callable<Thread>() {
+          @SuppressWarnings("deprecation")
           @Override public Thread call() {
             Thread thread = new Thread(runnable);
             thread.setDaemon(true);

--- a/server/src/test/java/org/apache/calcite/avatica/RemoteDriverMockTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/RemoteDriverMockTest.java
@@ -39,9 +39,9 @@ import java.util.concurrent.Callable;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/RemoteDriverTest.java
@@ -72,6 +72,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertArrayEquals;
@@ -79,7 +80,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/server/src/test/java/org/apache/calcite/avatica/jdbc/JdbcMetaTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/jdbc/JdbcMetaTest.java
@@ -38,8 +38,8 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**

--- a/server/src/test/java/org/apache/calcite/avatica/remote/AlternatingRemoteMetaTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/remote/AlternatingRemoteMetaTest.java
@@ -38,6 +38,8 @@ import org.junit.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -52,9 +54,9 @@ import java.util.Map;
 import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -157,8 +159,8 @@ public class AlternatingRemoteMetaTest {
       int index = urlStr.indexOf(comma);
       if (-1 == index) {
         try {
-          return Collections.singletonList(new URL(urlStr));
-        } catch (MalformedURLException e) {
+          return Collections.singletonList(new URI(urlStr).toURL());
+        } catch (MalformedURLException | URISyntaxException e) {
           throw new RuntimeException(e);
         }
       }
@@ -166,8 +168,8 @@ public class AlternatingRemoteMetaTest {
       // String split w/o regex
       while (-1 != index) {
         try {
-          urls.add(new URL(urlStr.substring(prevIndex, index)));
-        } catch (MalformedURLException e) {
+          urls.add(new URI(urlStr.substring(prevIndex, index)).toURL());
+        } catch (MalformedURLException | URISyntaxException e) {
           throw new RuntimeException(e);
         }
         prevIndex = index + 1;
@@ -176,8 +178,8 @@ public class AlternatingRemoteMetaTest {
 
       // Get the last one
       try {
-        urls.add(new URL(urlStr.substring(prevIndex)));
-      } catch (MalformedURLException e) {
+        urls.add(new URI(urlStr.substring(prevIndex)).toURL());
+      } catch (MalformedURLException | URISyntaxException e) {
         throw new RuntimeException(e);
       }
 
@@ -382,15 +384,15 @@ public class AlternatingRemoteMetaTest {
   @Test public void testSingleUrlParsing() throws Exception {
     AlternatingDriver d = new AlternatingDriver();
     List<URL> urls = d.parseUrls("http://localhost:1234");
-    assertEquals(Arrays.asList(new URL("http://localhost:1234")), urls);
+    assertEquals(Arrays.asList(new URI("http://localhost:1234").toURL()), urls);
   }
 
   @Test public void testMultipleUrlParsing() throws Exception {
     AlternatingDriver d = new AlternatingDriver();
     List<URL> urls = d.parseUrls("http://localhost:1234,http://localhost:2345,"
         + "http://localhost:3456");
-    List<URL> expectedUrls = Arrays.asList(new URL("http://localhost:1234"),
-        new URL("http://localhost:2345"), new URL("http://localhost:3456"));
+    List<URL> expectedUrls = Arrays.asList(new URI("http://localhost:1234").toURL(),
+        new URI("http://localhost:2345").toURL(), new URI("http://localhost:3456").toURL());
     assertEquals(expectedUrls, urls);
   }
 }

--- a/server/src/test/java/org/apache/calcite/avatica/remote/RemoteMetaTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/remote/RemoteMetaTest.java
@@ -51,6 +51,7 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.sql.Array;
@@ -73,12 +74,12 @@ import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -504,7 +505,7 @@ public class RemoteMetaTest {
   @Test public void testServerAddressInResponse() throws Exception {
     ConnectionSpec.getDatabaseLock().lock();
     try {
-      URL url = new URL("http://localhost:" + this.port);
+      URL url = new URI("http://localhost:" + this.port).toURL();
       AvaticaHttpClient httpClient = new AvaticaHttpClientImpl(url);
       byte[] request;
 
@@ -671,7 +672,7 @@ public class RemoteMetaTest {
   }
 
   @Test public void testMalformedRequest() throws Exception {
-    URL url = new URL("http://localhost:" + this.port);
+    URL url = new URI("http://localhost:" + this.port).toURL();
 
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod("POST");

--- a/server/src/test/java/org/apache/calcite/avatica/server/BasicAuthHttpServerTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/server/BasicAuthHttpServerTest.java
@@ -27,14 +27,15 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.util.Properties;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -165,7 +166,7 @@ public class BasicAuthHttpServerTest extends HttpAuthBase {
 
   @Test
   public void testServerVersionNotReturnedForUnauthorisedAccess() throws Exception {
-    URL httpServerUrl = new URL("http://localhost:" + server.getPort());
+    URL httpServerUrl = new URI("http://localhost:" + server.getPort()).toURL();
     HttpURLConnection conn = (HttpURLConnection) httpServerUrl.openConnection();
     conn.setRequestMethod("GET");
     assertEquals("Unauthorized response status code", 401, conn.getResponseCode());

--- a/server/src/test/java/org/apache/calcite/avatica/server/CustomAuthHttpServerTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/server/CustomAuthHttpServerTest.java
@@ -45,8 +45,8 @@ import java.util.Properties;
 import java.util.concurrent.Callable;
 import javax.servlet.http.HttpServletRequest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**

--- a/server/src/test/java/org/apache/calcite/avatica/server/DigestAuthHttpServerTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/server/DigestAuthHttpServerTest.java
@@ -27,14 +27,15 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.util.Properties;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -177,7 +178,7 @@ public class DigestAuthHttpServerTest extends HttpAuthBase {
   }
   @Test
   public void testServerVersionNotReturnedForUnauthorisedAccess() throws Exception {
-    URL httpServerUrl = new URL("http://localhost:" + server.getPort());
+    URL httpServerUrl = new URI("http://localhost:" + server.getPort()).toURL();
     HttpURLConnection conn = (HttpURLConnection) httpServerUrl.openConnection();
     conn.setRequestMethod("GET");
     assertEquals("Unauthorized response status code", 401, conn.getResponseCode());

--- a/server/src/test/java/org/apache/calcite/avatica/server/HttpQueryStringParameterRemoteUserExtractorTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/server/HttpQueryStringParameterRemoteUserExtractorTest.java
@@ -33,8 +33,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**

--- a/server/src/test/java/org/apache/calcite/avatica/server/HttpServerSpnegoWithoutJaasTest.java
+++ b/server/src/test/java/org/apache/calcite/avatica/server/HttpServerSpnegoWithoutJaasTest.java
@@ -45,7 +45,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.Properties;
@@ -81,7 +81,7 @@ public class HttpServerSpnegoWithoutJaasTest {
   private static boolean isKdcStarted = false;
   private static boolean isHttpServerStarted = false;
 
-  private static URL httpServerUrl;
+  private static URI httpServerUri;
 
   @BeforeClass public static void setupKdc() throws Exception {
     kdc = new SimpleKdcServer();
@@ -144,13 +144,13 @@ public class HttpServerSpnegoWithoutJaasTest {
     httpServer.start();
     isHttpServerStarted = true;
 
-    httpServerUrl = new URL("http://" + SpnegoTestUtil.KDC_HOST + ":" + httpServer.getPort());
-    LOG.info("HTTP server running at {}", httpServerUrl);
+    httpServerUri = new URI("http://" + SpnegoTestUtil.KDC_HOST + ":" + httpServer.getPort());
+    LOG.info("HTTP server running at {}", httpServerUri);
   }
 
   @AfterClass public static void stopKdc() throws Exception {
     if (isHttpServerStarted) {
-      LOG.info("Stopping HTTP server at {}", httpServerUrl);
+      LOG.info("Stopping HTTP server at {}", httpServerUri);
       httpServer.stop();
     }
 
@@ -181,16 +181,16 @@ public class HttpServerSpnegoWithoutJaasTest {
   }
 
   @Test public void testNormalClientsDisallowed() throws Exception {
-    LOG.info("Connecting to {}", httpServerUrl.toString());
-    HttpURLConnection conn = (HttpURLConnection) httpServerUrl.openConnection();
+    LOG.info("Connecting to {}", httpServerUri.toString());
+    HttpURLConnection conn = (HttpURLConnection) httpServerUri.toURL().openConnection();
     conn.setRequestMethod("GET");
     // Authentication should fail because we didn't provide anything
     assertEquals(401, conn.getResponseCode());
   }
 
   @Test public void testServerVersionNotReturnedForUnauthorisedAccess() throws Exception {
-    LOG.info("Connecting to {}", httpServerUrl.toString());
-    HttpURLConnection conn = (HttpURLConnection) httpServerUrl.openConnection();
+    LOG.info("Connecting to {}", httpServerUri.toString());
+    HttpURLConnection conn = (HttpURLConnection) httpServerUri.toURL().openConnection();
     conn.setRequestMethod("GET");
     assertEquals("Unauthorized response status code", 401, conn.getResponseCode());
     assertNull("Server information was not expected", conn.getHeaderField("server"));
@@ -233,7 +233,7 @@ public class HttpServerSpnegoWithoutJaasTest {
 
         // Passes the GSSCredential into the HTTP client implementation
         final AvaticaCommonsHttpClientImpl httpClient =
-            new AvaticaCommonsHttpClientImpl(httpServerUrl);
+            new AvaticaCommonsHttpClientImpl(httpServerUri);
         httpClient.setHttpClientPool(pool, config);
         httpClient.setGSSCredential(credential);
 


### PR DESCRIPTION
Fixes applied are:
 * move `new URL(...)` to `new URI(...).toUrl()`
 * move `Assert.assertThat(...)` to `MatcherAssert.assertThat(...)`
 * move `ExpectedException` ~to `Assert.assertThrows(...)`~ use manual code since Guava version changes cause the code to see both 4.12 and 4.13.1 JUnit versions.
 * in all other cases either propagate the deprecation or suppress it.