### PR TITLE
CALCITE-3533 - Map non-jdbc data types to ANY in JdbcSchema

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/SqlType.java
+++ b/core/src/main/java/org/apache/calcite/avatica/SqlType.java
@@ -378,7 +378,11 @@ public enum SqlType {
   public static SqlType valueOf(int type) {
     final SqlType sqlType = BY_ID.get(type);
     if (sqlType == null) {
-      throw new IllegalArgumentException("Unknown SQL type " + type);
+      // In most cases the ANY type will allow non-standard types to be displayable in the query requests.
+      // However, I think we should add the ability to specify a non-standard type factory
+      // that can be referenced here to see if the type is supported.
+      // For now, we will just return ANY to unblock users of databases that support non-standard types.
+      return ANY;
     }
     return sqlType;
   }

--- a/core/src/main/java/org/apache/calcite/avatica/SqlType.java
+++ b/core/src/main/java/org/apache/calcite/avatica/SqlType.java
@@ -378,10 +378,11 @@ public enum SqlType {
   public static SqlType valueOf(int type) {
     final SqlType sqlType = BY_ID.get(type);
     if (sqlType == null) {
-      // In most cases the ANY type will allow non-standard types to be displayable in the query requests.
-      // However, I think we should add the ability to specify a non-standard type factory
-      // that can be referenced here to see if the type is supported.
-      // For now, we will just return ANY to unblock users of databases that support non-standard types.
+      // In most cases the ANY type will allow non-standard types to be displayable in
+      // the query requests.  However, I think we should add the ability to specify
+      // a non-standard type factory that can be referenced here to see if the type is supported.
+      // For now, we will just return ANY to unblock users of databases
+      // that support non-standard types.
       return ANY;
     }
     return sqlType;

--- a/core/src/test/java/org/apache/calcite/avatica/SqlTypeTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/SqlTypeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.avatica;
+
+import org.junit.Test;
+
+import java.sql.Types;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for {@link SqlType}.
+ */
+public class SqlTypeTest {
+
+  @Test public void ensureAnyIsGivenForNonStandardSqlTypes() {
+    // Arrange
+    // Oracle TIMESTAMP WITH TIME ZONE
+    int timestampWithTimeZoneTypeValue = -101;
+    // SQL server DateTimeOffset
+    int dateTimeOffset = -155;
+
+    // Act
+    SqlType tsSqlType = SqlType.valueOf(timestampWithTimeZoneTypeValue);
+    SqlType dtoSqlType = SqlType.valueOf(dateTimeOffset);
+
+    // Assert
+    assertEquals(SqlType.ANY, tsSqlType);
+    assertEquals(SqlType.ANY, dtoSqlType);
+  }
+  
+  @Test public void ensureStandardSqlTypesAreFound() {
+    // Arrange
+    int doubleTypeValue = Types.DOUBLE;
+    int varcharTypeValue = Types.VARCHAR;
+
+    // Act
+    SqlType doubleSqlType = SqlType.valueOf(doubleTypeValue);
+    SqlType varcharSqlType = SqlType.valueOf(varcharTypeValue);
+
+    // Assert
+    assertEquals(SqlType.DOUBLE, doubleSqlType);
+    assertEquals(SqlType.VARCHAR, varcharSqlType);
+  }
+}

--- a/core/src/test/java/org/apache/calcite/avatica/SqlTypeTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/SqlTypeTest.java
@@ -20,6 +20,7 @@ package org.apache.calcite.avatica;
 import org.junit.Test;
 
 import java.sql.Types;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
@@ -43,18 +44,20 @@ public class SqlTypeTest {
     assertEquals(SqlType.ANY, tsSqlType);
     assertEquals(SqlType.ANY, dtoSqlType);
   }
-  
+
   @Test public void ensureStandardSqlTypesAreFound() {
     // Arrange
-    int doubleTypeValue = Types.DOUBLE;
-    int varcharTypeValue = Types.VARCHAR;
+    Map<Integer, SqlType> typeMap = new HashMap<>();
 
-    // Act
-    SqlType doubleSqlType = SqlType.valueOf(doubleTypeValue);
-    SqlType varcharSqlType = SqlType.valueOf(varcharTypeValue);
+    for (SqlType sqlType : SqlType.values()) {
+      typeMap.put(sqlType.id, sqlType);
+    }
 
-    // Assert
-    assertEquals(SqlType.DOUBLE, doubleSqlType);
-    assertEquals(SqlType.VARCHAR, varcharSqlType);
+    Set<Integer> typeValues = typeMap.keySet();
+
+    // Act and Assert
+    for (Integer typeValue : typeValues) {
+      assertEquals(typeMap.get(typeValue), SqlType.valueOf(typeValue));
+    }
   }
 }


### PR DESCRIPTION
This PR allows non-standards JDBC/SQL types to be processed as `ANY`.  Databases such as Oracle and SQLServer (among others) often support SQL types that are not defined as part of the standard Java JDBC type mapping.  

Currently Avatica (and by proxy Calcite) throw an exception when these types are encountered.  However, for many non-standard types this prevents the query from executing successfully even though the results are retrieved and displayed correctly when `ANY` is used for these scenarios (SQLSever's DataTimeOffset for example).  

While this is not a fix per se I do believe this is an improvement over the current behavior.  Types could be added directly, however, some types like Oracle's `DateTime With Offset` require the Oracle JDBC driver to convert.  This would mean including the JDBC driver in Avatica with is likely undesirable.  Ideally I think a nice enhancement would be to allow developers/users to specify a non-standard type conversion class/factory that could be called when these types are encountered while embedding any needed libraries (I'm hoping to have a conversation around this and partake in the implementation).