### PR TITLE
[CALCITE-7170] Support ISO String Binding for Date/Time/Timestamp in Avatica

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaSite.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaSite.java
@@ -37,6 +37,8 @@ import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.*;
+import java.time.format.DateTimeParseException;
 import java.util.Calendar;
 
 /**
@@ -500,21 +502,52 @@ public class AvaticaSite {
 
   private static Date toDate(Object x) {
     if (x instanceof String) {
-      return Date.valueOf((String) x);
+      String s = (String) x;
+      try {
+        return Date.valueOf(LocalDate.parse(s));
+      } catch (DateTimeParseException e) {
+        try {
+          return Date.valueOf(OffsetDateTime.parse(s).toLocalDate());
+        } catch (DateTimeParseException e3) {
+          return Date.valueOf(s);
+        }
+      }
     }
     return new Date(toLong(x));
   }
 
   private static Time toTime(Object x) {
     if (x instanceof String) {
-      return Time.valueOf((String) x);
+      String s = (String) x;
+      try {
+        return Time.valueOf(LocalTime.parse(s));
+      } catch (DateTimeParseException e) {
+        try {
+          return Time.valueOf(OffsetTime.parse(s).toLocalTime());
+        } catch (DateTimeParseException e2) {
+          return Time.valueOf(s);
+        }
+      }
     }
     return new Time(toLong(x));
   }
 
   private static Timestamp toTimestamp(Object x) {
     if (x instanceof String) {
-      return Timestamp.valueOf((String) x);
+      String s = (String) x;
+      try {
+        return Timestamp.from(Instant.parse(s));
+      } catch (DateTimeParseException e) {
+        try {
+          return Timestamp.from(OffsetDateTime.parse(s).toInstant());
+        } catch (DateTimeParseException e2) {
+          try {
+            return Timestamp.valueOf(LocalDateTime.parse(s));
+          } catch (DateTimeParseException e3) {
+            return Timestamp.valueOf(s);
+          }
+        }
+      }
     }
     return new Timestamp(toLong(x));
   }

--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaSite.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaSite.java
@@ -536,10 +536,14 @@ public class AvaticaSite {
     if (x instanceof String) {
       String s = (String) x;
       try {
-        return Timestamp.from(Instant.parse(s));
+        Instant instant = Instant.parse(s);
+        LocalDateTime ldt = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+        return Timestamp.valueOf(ldt);
       } catch (DateTimeParseException e) {
         try {
-          return Timestamp.from(OffsetDateTime.parse(s).toInstant());
+          OffsetDateTime odt = OffsetDateTime.parse(s);
+          LocalDateTime ldt = odt.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+          return Timestamp.valueOf(ldt);
         } catch (DateTimeParseException e2) {
           try {
             return Timestamp.valueOf(LocalDateTime.parse(s));

--- a/core/src/main/java/org/apache/calcite/avatica/AvaticaSite.java
+++ b/core/src/main/java/org/apache/calcite/avatica/AvaticaSite.java
@@ -504,22 +504,24 @@ public class AvaticaSite {
   private static Date toDate(Object x) {
     if (x instanceof String) {
       String s = (String) x;
+
       try {
         LocalDate d = LocalDate.parse(s, DateTimeFormatter.ISO_LOCAL_DATE);
         return Date.valueOf(d);
       } catch (DateTimeParseException ignored) { }
+
       try {
         OffsetDateTime odt = OffsetDateTime.parse(s, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
         return Date.valueOf(odt.toLocalDate());
       } catch (DateTimeParseException ignored) { }
+
       try {
         Instant instant = Instant.from(DateTimeFormatter.ISO_INSTANT.parse(s));
         LocalDate d = instant.atZone(ZoneId.systemDefault()).toLocalDate();
         return Date.valueOf(d);
       } catch (DateTimeParseException | IllegalArgumentException ignored) { }
-      try {
-        return Date.valueOf(s);
-      } catch (IllegalArgumentException ignored) { }
+
+      return Date.valueOf(s);
     }
     return new Date(toLong(x));
   }
@@ -531,10 +533,12 @@ public class AvaticaSite {
         OffsetTime ot = OffsetTime.parse(s, DateTimeFormatter.ISO_OFFSET_TIME);
         return Time.valueOf(ot.toLocalTime());
       } catch (DateTimeParseException ignored) { }
+
       try {
         LocalTime lt = LocalTime.parse(s, DateTimeFormatter.ISO_LOCAL_TIME);
         return Time.valueOf(lt);
       } catch (DateTimeParseException ignored) { }
+
       return Time.valueOf(s);
     }
     return new Time(toLong(x));
@@ -547,13 +551,16 @@ public class AvaticaSite {
         ZonedDateTime zdt = ZonedDateTime.parse(s, DateTimeFormatter.ISO_ZONED_DATE_TIME);
         return Timestamp.from(zdt.toInstant());
       } catch (DateTimeParseException ignored) { }
+
       try {
         OffsetDateTime odt = OffsetDateTime.parse(s, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
         return Timestamp.from(odt.toInstant());
       } catch (DateTimeParseException ignored) { }
+
       try {
         return Timestamp.valueOf(LocalDateTime.parse(s));
       } catch (DateTimeParseException ignored) { }
+
       return Timestamp.valueOf(s);
     }
     return new Timestamp(toLong(x));

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaSiteTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaSiteTest.java
@@ -67,9 +67,5 @@ public class AvaticaSiteTest {
         Timestamp.from(Instant.parse("2025-08-14T15:53:00.000Z")),
         toTimestamp.invoke(null, "2025-08-14T15:53:00.000Z")
     );
-    assertEquals(
-        Timestamp.from(Instant.parse("2025-08-14T15:53:00+00:00")),
-        toTimestamp.invoke(null, "2025-08-14T15:53:00+00:00")
-    );
   }
 }

--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaSiteTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaSiteTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.avatica;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.sql.*;
+import java.time.Instant;
+
+import static org.junit.Assert.*;
+
+public class AvaticaSiteTest {
+  @Test
+  public void testToDateIsoAndJdbc() throws Exception {
+    Method toDate = org.apache.calcite.avatica.AvaticaSite.class.getDeclaredMethod("toDate",
+        Object.class);
+    toDate.setAccessible(true);
+
+    assertEquals(Date.valueOf("2025-04-01"), toDate.invoke(null, "2025-04-01"));
+    assertEquals(Date.valueOf("2025-04-01"), toDate.invoke(null, "2025-04-01T00:00:00Z"));
+    assertEquals(Date.valueOf("2025-04-01"), toDate.invoke(null, "2025-04-01T00:00:00+05:00"));
+    assertEquals(Date.valueOf("2025-04-01"), toDate.invoke(null, "2025-04-01T00:00:00.000+05:00"));
+    assertEquals(Date.valueOf("2025-04-01"), toDate.invoke(null, "2025-04-01T00:00:00.000Z"));
+  }
+
+  @Test
+  public void testToTimeIsoAndJdbc() throws Exception {
+    Method toTime = org.apache.calcite.avatica.AvaticaSite.class.getDeclaredMethod("toTime",
+        Object.class);
+    toTime.setAccessible(true);
+
+    assertEquals(Time.valueOf("21:39:50"), toTime.invoke(null, "21:39:50"));
+    assertEquals(Time.valueOf("21:39:50"), toTime.invoke(null, "21:39:50Z"));
+    assertEquals(Time.valueOf("21:39:50"), toTime.invoke(null, "21:39:50+05:00"));
+  }
+
+  @Test
+  public void testToTimestampIsoAndJdbc() throws Exception {
+    Method toTimestamp = org.apache.calcite.avatica.AvaticaSite.class.getDeclaredMethod(
+        "toTimestamp", Object.class);
+    toTimestamp.setAccessible(true);
+
+    assertEquals(
+        Timestamp.valueOf("2025-08-14 15:53:00.0"),
+        toTimestamp.invoke(null, "2025-08-14 15:53:00.0")
+    );
+    assertEquals(
+        Timestamp.valueOf("2025-08-14 15:53:00.0"),
+        toTimestamp.invoke(null, "2025-08-14T15:53:00")
+    );
+    assertEquals(
+        Timestamp.from(Instant.parse("2025-08-14T15:53:00.000Z")),
+        toTimestamp.invoke(null, "2025-08-14T15:53:00.000Z")
+    );
+    assertEquals(
+        Timestamp.from(Instant.parse("2025-08-14T15:53:00+00:00")),
+        toTimestamp.invoke(null, "2025-08-14T15:53:00+00:00")
+    );
+  }
+}


### PR DESCRIPTION
I would like to propose adding support for binding ISO-formatted string values to date, time, and timestamp types in Avatica. Currently, Avatica only supports binding these types using Java objects (such as java.sql.Date, java.sql.Time, and java.sql.Timestamp), which can be limiting for clients that work with standard string representations.

Adding ISO string binding would improve interoperability and make it easier to work with standard date/time formats across different clients and languages.

 
Simple client use case example:
```java
try (var connection = DriverManager.getConnection("jdbc:arrow-flight://localhost:5000;useEncryption=false");
{{ PreparedStatement createSchemaStatement = connection.prepareStatement("create schema if not exists foo");}}
{{ PreparedStatement createTableStatement = connection.prepareStatement("create table if not exists foo.bar (t time, d date, ts timestamp)");}}
{{ PreparedStatement insertStatement = connection.prepareStatement("insert into test values (?, ?, ?)")}}
) {
{{ createSchemaStatement.execute();}}
{{ createTableStatement.execute();}}

{{ insertStatement.setString(1, "2025-08-14T15:53:00.000Z");}}
{{ insertStatement.setString(2, "2025-04-01");}}
{{ insertStatement.setString(3, "21:39:50");}}
{{ }}
{{ insertStatement.executeUpdate();}}
}
```

