### PR TITLE
avoid running static initializers in CursorFactory.fromProto

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/Meta.java
+++ b/core/src/main/java/org/apache/calcite/avatica/Meta.java
@@ -722,7 +722,10 @@ public interface Meta {
 
       if (proto.hasField(CLASS_NAME_DESCRIPTOR)) {
         try {
-          clz = Class.forName(proto.getClassName());
+          // Resolve without initializing: a server parsing this from an untrusted
+          // client must not run the named class's static initializer.
+          clz = Class.forName(proto.getClassName(), false,
+              CursorFactory.class.getClassLoader());
         } catch (ClassNotFoundException e) {
           throw new RuntimeException(e);
         }


### PR DESCRIPTION
CursorFactory.fromProto resolves a wire-supplied class name with Class.forName(String), which initializes the class and runs its static initializer. The server hits this while parsing an ExecuteRequest from an untrusted client (StatementHandle -> Signature -> CursorFactory), so a client can make the server load and initialize any class on its classpath. Resolve with the three-arg form and initialize=false; the class is still linked but no static code runs at parse time.